### PR TITLE
fix: CI Gate 检查逻辑 — keyword grep 升级为结构化正则 + P0-2 角色名修复

### DIFF
--- a/.github/workflows/bootstrap-sync.yml
+++ b/.github/workflows/bootstrap-sync.yml
@@ -72,5 +72,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .claude/skills/
-          git commit -m "chore: sync adf-prefix skills to .claude/skills"
+          git commit -m "chore: sync adf-prefix skills to .claude/skills [skip ci]"
           git push

--- a/.github/workflows/doc-pr-checks.yml
+++ b/.github/workflows/doc-pr-checks.yml
@@ -86,81 +86,84 @@ jobs:
           echo "Gate Status Check"
           echo "=========================================="
 
-          # Check PRD Gate 1
-          # Gate 1 要求: PM (必签) + 架构评审人 (必签)
+          # Pattern A regex: table row with role + date + decision
+          # Format: | 日期 | 评审人 | 备注 | 决策 |
+          # Valid decisions: Approved, Conditional, Rejected, Draft, 通过, 待评审, 驳回
+          check_sig() {
+            local DOC_FILE="$1"; local ROLE="$2"; local GATE_NAME="$3"
+            local SIG_LINE
+            # Must match: table row (starts with |) + role in column 2 + date (YYYY-MM-DD in col 1) + valid decision (col 4)
+            # Supports English decisions (Approved/Conditional/Rejected) and Chinese (通过/待评审/驳回)
+            SIG_LINE=$(grep "^|" "${DOC_FILE}" | grep "| ${ROLE} |" | grep -E "\| [0-9]{4}-[0-9]{2}-[0-9]{2} \|.*\| (Approved|Conditional|Rejected|Draft|通过|待评审|驳回)")
+            if [ -n "$SIG_LINE" ]; then
+              echo "  [${GATE_NAME}] Signature found: ${ROLE} ✓"
+              return 0
+            else
+              echo "  [${GATE_NAME}] FAILED: Missing required signature"
+              echo "    Required: ${ROLE} sign-off (评审人: ${ROLE} + 日期: YYYY-MM-DD + 决策: Approved/Conditional/Rejected)"
+              echo "    Fix: Add review record to Gate table in ${DOC_FILE}"
+              return 1
+            fi
+          }
+
+          FAILED=0
+
+          # === PRD Gate 1: PM + 架构师 ===
           PRD_FILE=$(ls docs/prd/PRD-${ISSUE}_*.md 2>/dev/null | head -1)
           if [ -n "$PRD_FILE" ]; then
             echo ""
             echo "[PRD Gate 1] Checking: $PRD_FILE"
             if grep -q "Gate 1" "$PRD_FILE" || grep -q "PRD Gate" "$PRD_FILE"; then
-              PM_SIG=$(grep -i "PM" "$PRD_FILE" | grep -i "sign" | head -1)
-              ARCH_SIG=$(grep -i "架构" "$PRD_FILE" | grep -i "sign" | head -1)
-              if [ -n "$PM_SIG" ] && [ -n "$ARCH_SIG" ]; then
-                echo "  [PRD Gate 1] Signatures: PM=present, 架构评审人=present"
-              else
-                echo "  [PRD Gate 1] FAILED: Missing required signatures (PM=${PM_SIG:+present}, 架构评审人=${ARCH_SIG:+present})"
-                exit 1
-              fi
+              check_sig "$PRD_FILE" "PM" "PRD Gate 1" || FAILED=1
+              check_sig "$PRD_FILE" "架构师" "PRD Gate 1" || FAILED=1
             else
               echo "  [PRD Gate 1] No Gate block found - document may not be ready for merge"
               exit 1
             fi
           fi
 
-          # Check Tech Gate 2
+          # === Tech Gate 2: PM + 技术负责人 + QA ===
           TECH_FILE=$(ls docs/tech/Tech-${ISSUE}_*.md 2>/dev/null | head -1)
           if [ -n "$TECH_FILE" ]; then
             echo ""
             echo "[Tech Gate 2] Checking: $TECH_FILE"
             if grep -q "Gate 2\|Tech Gate" "$TECH_FILE"; then
-              PM_SIG=$(grep -i "PM" "$TECH_FILE" | grep -i "sign" | head -1)
-              TECH_SIG=$(grep -i "技术评审人\|Tech Review" "$TECH_FILE" | grep -i "sign" | head -1)
-              QA_SIG=$(grep -i "QA" "$TECH_FILE" | grep -i "sign\|review" | head -1)
-              if [ -n "$PM_SIG" ] && [ -n "$TECH_SIG" ] && [ -n "$QA_SIG" ]; then
-                echo "  [Tech Gate 2] Signatures: PM=present, 技术评审人=present, QA=present"
-              else
-                echo "  [Tech Gate 2] FAILED: Missing required signatures (PM=${PM_SIG:+present}, 技术评审人=${TECH_SIG:+present}, QA=${QA_SIG:+present})"
-                exit 1
-              fi
+              check_sig "$TECH_FILE" "PM" "Tech Gate 2" || FAILED=1
+              check_sig "$TECH_FILE" "技术负责人" "Tech Gate 2" || FAILED=1
+              check_sig "$TECH_FILE" "QA" "Tech Gate 2" || FAILED=1
             else
               echo "  [Tech Gate 2] No Gate block found - document may not be ready for merge"
               exit 1
             fi
           fi
 
-          # Check QA Case Design Gate
+          # === QA Case Design Gate 3: PM + 架构师 + Engineer ===
           QA_FILE=$(ls docs/qa/QA-${ISSUE}_*.md 2>/dev/null | head -1)
           if [ -n "$QA_FILE" ]; then
             echo ""
             echo "[QA Case Design Gate 3] Checking: $QA_FILE"
             if grep -q "Gate\|Sign" "$QA_FILE"; then
-              PM_SIG=$(grep -i "PM" "$QA_FILE" | grep -i "sign" | head -1)
-              ARCH_SIG=$(grep -i "架构师\|Architect" "$QA_FILE" | grep -i "sign" | head -1)
-              ENG_SIG=$(grep -i "Engineer\|ENG" "$QA_FILE" | grep -i "sign\|review" | head -1)
-              if [ -n "$PM_SIG" ] && [ -n "$ARCH_SIG" ] && [ -n "$ENG_SIG" ]; then
-                echo "  [QA Case Design Gate 3] Signatures: PM=present, 架构师=present, Engineer=present"
-              else
-                echo "  [QA Case Design Gate 3] FAILED: Missing required signatures (PM=${PM_SIG:+present}, 架构师=${ARCH_SIG:+present}, Engineer=${ENG_SIG:+present})"
-                exit 1
-              fi
+              check_sig "$QA_FILE" "PM" "QA Gate 3" || FAILED=1
+              check_sig "$QA_FILE" "架构师" "QA Gate 3" || FAILED=1
+              check_sig "$QA_FILE" "Engineer" "QA Gate 3" || FAILED=1
             fi
           fi
 
-          # Check QA Test Report Gate 5
+          # === QA Test Report Gate 5: QA + PM + Engineer ===
           if [ -n "$QA_FILE" ]; then
             echo ""
             echo "[QA Test Report Gate 5] Checking: $QA_FILE"
             if grep -q "Gate\|Sign\|Report\|Test" "$QA_FILE"; then
-              QA_SIG=$(grep -i "QA" "$QA_FILE" | grep -i "sign\|review" | head -1)
-              PM_SIG=$(grep -i "PM" "$QA_FILE" | grep -i "sign" | head -1)
-              ENG_SIG=$(grep -i "Engineer\|ENG" "$QA_FILE" | grep -i "sign\|review" | head -1)
-              if [ -n "$QA_SIG" ] && [ -n "$PM_SIG" ] && [ -n "$ENG_SIG" ]; then
-                echo "  [QA Test Report Gate 5] Signatures: QA=present, PM=present, Engineer=present"
-              else
-                echo "  [QA Test Report Gate 5] FAILED: Missing required signatures (QA=${QA_SIG:+present}, PM=${PM_SIG:+present}, Engineer=${ENG_SIG:+present})"
-                exit 1
-              fi
+              check_sig "$QA_FILE" "QA" "QA Gate 5" || FAILED=1
+              check_sig "$QA_FILE" "PM" "QA Gate 5" || FAILED=1
+              check_sig "$QA_FILE" "Engineer" "QA Gate 5" || FAILED=1
             fi
+          fi
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo ""
+            echo "[Gate Check] FAILED - see details above"
+            exit 1
           fi
 
           echo ""
@@ -181,8 +184,8 @@ jobs:
           echo "  - QA: docs/qa/QA-${{ steps.extract-issue.outputs.issue_number }}_*.md"
           echo ""
           echo "Gate Status:"
-          echo "  - PRD Gate 1: PM + 架构评审人"
-          echo "  - Tech Gate 2: PM + 技术评审人 + QA"
+          echo "  - PRD Gate 1: PM + 架构师"
+          echo "  - Tech Gate 2: PM + 技术负责人 + QA"
           echo "  - QA Case Design Gate 3: PM + 架构师 + Engineer"
           echo "  - Implementation Gate 4: Engineer + 架构师"
           echo "  - QA Test Report Gate 5: QA + PM + Engineer"

--- a/.github/workflows/doc-pr-checks.yml
+++ b/.github/workflows/doc-pr-checks.yml
@@ -106,30 +106,48 @@ jobs:
             fi
           }
 
+          # Check a role, trying multiple alias names (OR logic — any alias match passes)
+          check_sig_alias() {
+            local DOC_FILE="$1"; local ROLE="$2"; local GATE_NAME="$3"; shift 3
+            local ALIASES="$*"
+            for ALIAS in $ALIASES; do
+              local SIG_LINE
+              SIG_LINE=$(grep "^|" "${DOC_FILE}" | grep "| ${ALIAS} |" | grep -E "\| [0-9]{4}-[0-9]{2}-[0-9]{2} \|.*\| (Approved|Conditional|Rejected|Draft|通过|待评审|驳回)" 2>/dev/null || true)
+              if [ -n "$SIG_LINE" ]; then
+                echo "  [${GATE_NAME}] Signature found: ${ALIAS} (matches '${ROLE}') ✓"
+                return 0
+              fi
+            done
+            echo "  [${GATE_NAME}] FAILED: Missing required signature"
+            echo "    Required: ${ROLE} (alias: ${ALIASES})"
+            echo "    Fix: Add review record to Gate table in ${DOC_FILE}"
+            return 1
+          }
+
           FAILED=0
 
-          # === PRD Gate 1: PM + 架构师 ===
+          # === PRD Gate 1: PM + 架构评审人 (aliases: Architect) ===
           PRD_FILE=$(ls docs/prd/PRD-${ISSUE}_*.md 2>/dev/null | head -1)
           if [ -n "$PRD_FILE" ]; then
             echo ""
             echo "[PRD Gate 1] Checking: $PRD_FILE"
             if grep -q "Gate 1" "$PRD_FILE" || grep -q "PRD Gate" "$PRD_FILE"; then
               check_sig "$PRD_FILE" "PM" "PRD Gate 1" || FAILED=1
-              check_sig "$PRD_FILE" "架构师" "PRD Gate 1" || FAILED=1
+              check_sig_alias "$PRD_FILE" "架构评审人" "PRD Gate 1" "架构评审人 Team Lead Architect" || FAILED=1
             else
               echo "  [PRD Gate 1] No Gate block found - document may not be ready for merge"
               exit 1
             fi
           fi
 
-          # === Tech Gate 2: PM + 技术负责人 + QA ===
+          # === Tech Gate 2: PM + 技术负责人/技术评审人 + QA (aliases) ===
           TECH_FILE=$(ls docs/tech/Tech-${ISSUE}_*.md 2>/dev/null | head -1)
           if [ -n "$TECH_FILE" ]; then
             echo ""
             echo "[Tech Gate 2] Checking: $TECH_FILE"
             if grep -q "Gate 2\|Tech Gate" "$TECH_FILE"; then
               check_sig "$TECH_FILE" "PM" "Tech Gate 2" || FAILED=1
-              check_sig "$TECH_FILE" "技术负责人" "Tech Gate 2" || FAILED=1
+              check_sig_alias "$TECH_FILE" "技术负责人" "Tech Gate 2" "技术负责人 技术评审人" || FAILED=1
               check_sig "$TECH_FILE" "QA" "Tech Gate 2" || FAILED=1
             else
               echo "  [Tech Gate 2] No Gate block found - document may not be ready for merge"
@@ -137,24 +155,24 @@ jobs:
             fi
           fi
 
-          # === QA Case Design Gate 3: PM + 架构师 + Engineer ===
+          # === QA Case Design Gate 3: PM + 架构师 + Engineer (aliases: Architect) ===
           QA_FILE=$(ls docs/qa/QA-${ISSUE}_*.md 2>/dev/null | head -1)
           if [ -n "$QA_FILE" ]; then
             echo ""
             echo "[QA Case Design Gate 3] Checking: $QA_FILE"
             if grep -q "Gate\|Sign" "$QA_FILE"; then
               check_sig "$QA_FILE" "PM" "QA Gate 3" || FAILED=1
-              check_sig "$QA_FILE" "架构师" "QA Gate 3" || FAILED=1
+              check_sig_alias "$QA_FILE" "架构师" "QA Gate 3" "架构师 Architect" || FAILED=1
               check_sig "$QA_FILE" "Engineer" "QA Gate 3" || FAILED=1
             fi
           fi
 
-          # === QA Test Report Gate 5: QA + PM + Engineer ===
+          # === QA Test Report Gate 5: QA + PM + Engineer (aliases: QA Engineer) ===
           if [ -n "$QA_FILE" ]; then
             echo ""
             echo "[QA Test Report Gate 5] Checking: $QA_FILE"
             if grep -q "Gate\|Sign\|Report\|Test" "$QA_FILE"; then
-              check_sig "$QA_FILE" "QA" "QA Gate 5" || FAILED=1
+              check_sig_alias "$QA_FILE" "QA" "QA Gate 5" "QA QA Engineer" || FAILED=1
               check_sig "$QA_FILE" "PM" "QA Gate 5" || FAILED=1
               check_sig "$QA_FILE" "Engineer" "QA Gate 5" || FAILED=1
             fi
@@ -184,7 +202,7 @@ jobs:
           echo "  - QA: docs/qa/QA-${{ steps.extract-issue.outputs.issue_number }}_*.md"
           echo ""
           echo "Gate Status:"
-          echo "  - PRD Gate 1: PM + 架构师"
+          echo "  - PRD Gate 1: PM + 架构评审人"
           echo "  - Tech Gate 2: PM + 技术负责人 + QA"
           echo "  - QA Case Design Gate 3: PM + 架构师 + Engineer"
           echo "  - Implementation Gate 4: Engineer + 架构师"

--- a/scripts/test_gate_regex.sh
+++ b/scripts/test_gate_regex.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Test script for doc-pr-checks.yml Gate regex pattern
+# Validates Pattern A: table row with role + date + decision
+# Usage: ./scripts/test_gate_regex.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+
+# Pattern A regex (same as doc-pr-checks.yml)
+check_sig() {
+    local DOC_FILE="$1"; local ROLE="$2"; local GATE_NAME="$3"
+    local SIG_LINE
+    SIG_LINE=$(grep "^|" "${DOC_FILE}" | grep "| ${ROLE} |" | grep -E "\| [0-9]{4}-[0-9]{2}-[0-9]{2} \|.*\| (Approved|Conditional|Rejected|Draft|通过|待评审|驳回)" 2>/dev/null || true)
+    if [ -n "$SIG_LINE" ]; then
+        echo "  ✓ [${GATE_NAME}] ${ROLE}: MATCH"
+        return 0
+    else
+        echo "  ✗ [${GATE_NAME}] ${ROLE}: NO MATCH"
+        return 1
+    fi
+}
+
+run_test() {
+    local DOC_FILE="$1"
+    local TEST_NAME="$2"
+    shift 2
+    while [ $# -gt 0 ]; do
+        local ROLE="$1"; shift
+        local EXPECTED="$1"; shift
+        if check_sig "$DOC_FILE" "$ROLE" "$TEST_NAME" 2>/dev/null; then
+            local ACTUAL="match"
+        else
+            local ACTUAL="no match"
+        fi
+        if [ "$EXPECTED" = "$ACTUAL" ]; then
+            echo "  ✓ ${ROLE}: expected=$EXPECTED actual=$ACTUAL"
+            ((PASS++))
+        else
+            echo "  ✗ ${ROLE}: expected=$EXPECTED actual=$ACTUAL"
+            ((FAIL++))
+        fi
+    done
+    echo ""
+}
+
+echo "=========================================="
+echo "Gate Regex Pattern Tests"
+echo "=========================================="
+echo ""
+
+# --- Test 1: Synthetic valid signatures ---
+echo "[Test 1] Synthetic valid signatures"
+TMPFILE=$(mktemp)
+cat > "$TMPFILE" << 'EOF'
+## 评审记录
+
+| 日期 | 评审人 | 备注 | 决策 |
+|---|---|---|---|
+| 2026-04-15 | PM | OK | Approved |
+| 2026-04-15 | 架构师 | Good | Approved |
+| 2026-04-15 | 技术负责人 | LGTM | Conditional |
+| 2026-04-15 | QA | Pass | Approved |
+| 2026-04-15 | Engineer | Done | Rejected |
+EOF
+run_test "$TMPFILE" "Test1" "PM" "match" "架构师" "match" "技术负责人" "match" "QA" "match" "Engineer" "match"
+rm "$TMPFILE"
+
+# --- Test 2: Pseudo-signatures should NOT match ---
+echo "[Test 2] Pseudo-signatures (should NOT match)"
+TMPFILE=$(mktemp)
+cat > "$TMPFILE" << 'EOF'
+## Notes
+需要 PM review 完成签字
+| 2026-04-15 | Architect | OK | Approved |
+| | QA | OK | Approved |
+| 2026-04-15 | PM | OK | 待评审 |
+| 2026-04-15 | 架构 | OK | Approved |
+EOF
+run_test "$TMPFILE" "Test2" "PM" "match" "架构师" "no match" "QA" "no match"
+rm "$TMPFILE"
+
+# --- Test 3: Existing documents (PRD-1, Tech-1, QA-1) - no Gate blocks ---
+echo "[Test 3] Existing docs without Gate blocks (should have no sigs)"
+for pair in "prd:PRD-1_v1:prd" "tech:Tech-1_v1:tech"; do
+    DIR="${pair%%:*}"; pair="${pair#*:}"
+    DOC="${pair%%:*}"; TEST="${pair#*:}"
+    FILE="$SCRIPT_DIR/../docs/${DIR}/${DOC}.md"
+    if [ -f "$FILE" ]; then
+        RESULT=$(grep "^|" "${FILE}" | grep "| PM |" | grep -E "\| [0-9]{4}-[0-9]{2}-[0-9]{2} \|.*\| (Approved|Conditional|Rejected|Draft|通过|待评审|驳回)" 2>/dev/null || true)
+        if [ -n "$RESULT" ]; then
+            echo "  ? [Test3] ${DOC}: Has PM signature (review record found)"
+        else
+            echo "  ✓ [Test3] ${DOC}: no PM signature (no Gate block)"
+        fi
+    fi
+done
+FILE="$SCRIPT_DIR/../docs/qa/QA-1_v1.md"
+if [ -f "$FILE" ]; then
+    RESULT=$(grep "^|" "${FILE}" | grep "| PM |" | grep -E "\| [0-9]{4}-[0-9]{2}-[0-9]{2} \|.*\| (Approved|Conditional|Rejected|Draft|通过|待评审|驳回)" 2>/dev/null || true)
+    if [ -n "$RESULT" ]; then
+        echo "  ? [Test3] QA-1_v1: Has PM signature (review record found)"
+    else
+        echo "  ✓ [Test3] QA-1_v1: no PM signature (no Gate block)"
+    fi
+fi
+echo ""
+
+# --- Test 4: PRD-5 review records ---
+# Actual decisions in file: "通过", "待评审", "已纳入...", "**Approved**", "v2", "**Approved**", "v3 — Approved"
+# Rows with valid decisions: Team Lead(通过), PM(待评审)
+# Rows with non-standard decisions: Architect(已纳入...), Team Lead(**Approved**), PM(v2), Team Lead(**Approved**), PM(v3 — Approved)
+echo "[Test 4] PRD-5 review record table"
+FILE="$SCRIPT_DIR/../docs/prd/005_adf_bootstrap_skill_system_2026-04-15.md"
+if [ -f "$FILE" ]; then
+    run_test "$FILE" "Test4" "Team Lead" "match" "PM" "match" "Architect" "no match"
+else
+    echo "  ! PRD-5 file not found"
+fi
+echo ""
+
+# --- Test 5: Tech-5 review records ---
+# All rows have standard decisions: Draft, Approved, Approved, Conditional, Approved
+echo "[Test 5] Tech-5 review record table"
+FILE="$SCRIPT_DIR/../docs/tech/Tech-5_v1.md"
+if [ -f "$FILE" ]; then
+    run_test "$FILE" "Test5" "架构师" "match" "PM" "match" "QA Engineer" "match" "Team Lead" "match"
+else
+    echo "  ! Tech-5 file not found"
+fi
+echo ""
+
+# --- Test 6: QA-5 review records ---
+# Only QA Engineer row has a decision value; PM/Architect/Engineer rows are placeholders
+echo "[Test 6] QA-5 review record table"
+FILE="$SCRIPT_DIR/../docs/qa/QA-5_v1.md"
+if [ -f "$FILE" ]; then
+    run_test "$FILE" "Test6" "QA Engineer" "match" "PM" "no match" "Architect" "no match" "Engineer" "no match"
+else
+    echo "  ! QA-5 file not found"
+fi
+echo ""
+
+# --- Summary ---
+echo "=========================================="
+echo "Results: PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -eq 0 ]; then
+    echo "All tests PASSED ✓"
+    exit 0
+else
+    echo "Some tests FAILED ✗"
+    exit 1
+fi

--- a/scripts/test_gate_regex.sh
+++ b/scripts/test_gate_regex.sh
@@ -58,12 +58,12 @@ cat > "$TMPFILE" << 'EOF'
 | 日期 | 评审人 | 备注 | 决策 |
 |---|---|---|---|
 | 2026-04-15 | PM | OK | Approved |
-| 2026-04-15 | 架构师 | Good | Approved |
+| 2026-04-15 | 架构评审人 | Good | Approved |
 | 2026-04-15 | 技术负责人 | LGTM | Conditional |
 | 2026-04-15 | QA | Pass | Approved |
 | 2026-04-15 | Engineer | Done | Rejected |
 EOF
-run_test "$TMPFILE" "Test1" "PM" "match" "架构师" "match" "技术负责人" "match" "QA" "match" "Engineer" "match"
+run_test "$TMPFILE" "Test1" "PM" "match" "架构评审人" "match" "技术负责人" "match" "QA" "match" "Engineer" "match"
 rm "$TMPFILE"
 
 # --- Test 2: Pseudo-signatures should NOT match ---
@@ -107,9 +107,9 @@ fi
 echo ""
 
 # --- Test 4: PRD-5 review records ---
-# Actual decisions in file: "通过", "待评审", "已纳入...", "**Approved**", "v2", "**Approved**", "v3 — Approved"
-# Rows with valid decisions: Team Lead(通过), PM(待评审)
-# Rows with non-standard decisions: Architect(已纳入...), Team Lead(**Approved**), PM(v2), Team Lead(**Approved**), PM(v3 — Approved)
+# Gate 1 roles: PM + 架构评审人 (alias: Architect)
+# Actual review records: Team Lead(通过), PM(待评审), Architect(已纳入)
+# With alias support, Architect now matches as 架构评审人
 echo "[Test 4] PRD-5 review record table"
 FILE="$SCRIPT_DIR/../docs/prd/005_adf_bootstrap_skill_system_2026-04-15.md"
 if [ -f "$FILE" ]; then
@@ -120,6 +120,8 @@ fi
 echo ""
 
 # --- Test 5: Tech-5 review records ---
+# Gate 3 roles: PM + 架构师 (alias: Architect)
+# Gate 2 roles: PM + 技术负责人 (alias: 技术评审人)
 # All rows have standard decisions: Draft, Approved, Approved, Conditional, Approved
 echo "[Test 5] Tech-5 review record table"
 FILE="$SCRIPT_DIR/../docs/tech/Tech-5_v1.md"
@@ -131,6 +133,7 @@ fi
 echo ""
 
 # --- Test 6: QA-5 review records ---
+# QA Gate 5 roles: QA (alias: QA Engineer) + PM + Engineer
 # Only QA Engineer row has a decision value; PM/Architect/Engineer rows are placeholders
 echo "[Test 6] QA-5 review record table"
 FILE="$SCRIPT_DIR/../docs/qa/QA-5_v1.md"
@@ -139,6 +142,47 @@ if [ -f "$FILE" ]; then
 else
     echo "  ! QA-5 file not found"
 fi
+echo ""
+
+# --- Test 7: Gate doc table vs body text role name alignment ---
+# Gate doc summary table: 架构评审人, 技术评审人
+# Gate doc body / Tech-5 records: 架构师, 技术负责人
+# Both sets should be recognized by CI check_sig_alias
+# Here we test that "Architect" matches (English alias for 架构师/架构评审人)
+echo "[Test 7] English role aliases recognized"
+TMPFILE=$(mktemp)
+cat > "$TMPFILE" << 'EOF'
+| 日期 | 评审人 | 备注 | 决策 |
+|---|---|---|---|
+| 2026-04-15 | Architect | Gate review | Approved |
+| 2026-04-15 | 技术评审人 | Gate review | Approved |
+| 2026-04-15 | QA Engineer | Gate review | Approved |
+EOF
+# "Architect" matches (English alias for 架构师/架构评审人)
+if check_sig "$TMPFILE" "Architect" "Test7" 2>/dev/null; then
+    echo "  ✓ [Test7] Architect: match (English alias for 架构师)"
+    ((PASS++))
+else
+    echo "  ✗ [Test7] Architect: no match"
+    ((FAIL++))
+fi
+# "技术评审人" matches (Gate doc table alias for 技术负责人)
+if check_sig "$TMPFILE" "技术评审人" "Test7" 2>/dev/null; then
+    echo "  ✓ [Test7] 技术评审人: match (Gate doc table alias)"
+    ((PASS++))
+else
+    echo "  ✗ [Test7] 技术评审人: no match"
+    ((FAIL++))
+fi
+# "QA Engineer" matches (English alias for QA)
+if check_sig "$TMPFILE" "QA Engineer" "Test7" 2>/dev/null; then
+    echo "  ✓ [Test7] QA Engineer: match (English alias for QA)"
+    ((PASS++))
+else
+    echo "  ✗ [Test7] QA Engineer: no match"
+    ((FAIL++))
+fi
+rm "$TMPFILE"
 echo ""
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

- **P0-1 修复**：将 `doc-pr-checks.yml` Gate 签字检查从 keyword grep（`grep -i "PM" | grep -i "sign"`）升级为结构化 Pattern A 正则，验证表格行同时包含角色名 + 日期(YYYY-MM-DD) + 有效决策
- **P0-2 修复**：Gate 1 角色名从 `"架构"` 改为 `"架构评审人"`（C4 决策，与 Gate 文档一致）
- **角色别名支持**：通过 `check_sig_alias()` 函数支持 Gate 文档表/正文/Review Record 之间的角色名别名映射
- **中文决策支持**：正则支持 `通过/待评审/驳回`（中文）+ `Approved/Conditional/Rejected/Draft`（英文）
- **友好错误输出**：Gate 检查失败时输出缺失角色 + 修复建议
- **bootstrap-sync 加固**：commit message 添加 `[skip ci]` 防止循环触发

## Test Verification

\`\`\`bash
bash scripts/test_gate_regex.sh
# Results: PASS=22 FAIL=0 — All tests PASSED ✓
\`\`\`

测试覆盖：
- 合成有效签字（5种角色）
- 伪签字拒绝（free text、无日期、无有效决策、非标准角色名）
- 现有文档格式覆盖（PRD-1/Tech-1/QA-1 无 Gate 块 → 正确拒绝）
- PRD-5/Tech-5/QA-5 实际 Review Record 表格
- English role aliases (Architect, QA Engineer, 技术评审人)

## Files Changed

| 文件 | 变更 |
|------|------|
| `.github/workflows/doc-pr-checks.yml` | Gate 检查逻辑重写（Pattern A 正则 + role aliases） |
| `.github/workflows/bootstrap-sync.yml` | commit message 加固 |
| `scripts/test_gate_regex.sh` | 新增（测试脚本，22 项测试）|

## Gate Status

| Gate | 必签角色 | 状态 |
|------|---------|------|
| PRD Gate 1 | PM + 架构评审人 | ✅ |
| Tech Gate 2 | PM + 技术负责人 + QA | ✅ |
| QA Gate 3 | PM + 架构师 + Engineer | ✅ |
| QA Gate 5 | QA + PM + Engineer | ✅ |

## 追溯

- Tech Spec: `docs/tech/Tech-5_v1.md`
- PRD: `docs/prd/005_adf_bootstrap_skill_system_2026-04-15.md`
- QA: `docs/qa/QA-5_v1.md`

🤖 Generated with [Claude Code](https://claude.ai/code)