### PR TITLE
docs: close out issue 19 review package (Refs #19)

### DIFF
--- a/.claude/results/comment_17_20260422_040121.json
+++ b/.claude/results/comment_17_20260422_040121.json
@@ -5,5 +5,6 @@
   "agent": "product-manager",
   "source_comment_url": "",
   "created_at": "2026-04-22T04:01:21Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/.claude/results/comment_19_20260422_040634.json
+++ b/.claude/results/comment_19_20260422_040634.json
@@ -5,5 +5,6 @@
   "agent": "product-manager",
   "source_comment_url": "",
   "created_at": "2026-04-22T04:06:34Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/.claude/results/comment_19_20260422_135006.json
+++ b/.claude/results/comment_19_20260422_135006.json
@@ -5,5 +5,6 @@
   "agent": "architect",
   "source_comment_url": "",
   "created_at": "2026-04-22T13:50:06Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/.claude/results/comment_19_20260422_135607.json
+++ b/.claude/results/comment_19_20260422_135607.json
@@ -5,5 +5,6 @@
   "agent": "architect",
   "source_comment_url": "",
   "created_at": "2026-04-22T13:56:07Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/.claude/results/comment_19_20260422_135607.json
+++ b/.claude/results/comment_19_20260422_135607.json
@@ -1,0 +1,9 @@
+{
+  "type": "issue-comment",
+  "issue_number": 19,
+  "body": "**Agent**: architect\n**Date**: 2026-04-22T13:56:07Z\n**Source**: [Issue #19 Comment]()\n---\n\n## Architect Gate 1 PRD Review — Issue #19\n\n**角色**: Architect  \n**结论**: ✅ Approved  \n**日期**: 2026-04-22\n\n### PRD 版本\n`docs/prd/019_installation_script_doc_path_2026-04-22.md` v2.0\n\n### 评审结论\n\n| 评审维度 | 结论 |\n|----------|------|\n| 主线定义（#19 唯一主线，#30 duplicate/background） | ✅ 接受 |\n| 六类产物范围（docs/prompts/skills/workflows/shared/templates） | ✅ 技术可行 |\n| 安装态 skill namespace（无 adf- 前缀） | ✅ 与 bootstrap-sync 边界清晰 |\n| 关键入口真实读取（SKILL/workflow/template） | ✅ 运行时方案可支撑 |\n| 逐层依赖分析范围（§4.5） | ✅ 起点合理，覆盖完整 |\n| 打包目录准入/准出规则（§4.6） | ✅ 准入4条+准出4条+审批流程完备 |\n| CLAUDE.md 规则沉淀（§4.7） | ✅ 与现有架构兼容 |\n| 验收标准 7.7-7.9 | ✅ 可测试 |\n| 风险矩阵 | ✅ 7项风险完整覆盖 |\n\n### v1.0 Conditional 条件状态\n\n| 条件 | v2.0 解决方式 |\n|------|--------------|\n| 条件1：定义\"关键文件\"最小清单 | ✅ 已解决 — §4.5 依赖分析机制自然产出\"最小必要打包目录集\" |\n| 条件2：bootstrap-sync 协同机制细化 | ⚠️ 推迟到 Tech Spec 阶段 — §4.6 准入规则提供框架 |\n\n### 签字\n\n**Architect[✅] Approved** — PRD v2.0 新增三个交付域完整、准入/准出规则清晰、风险覆盖完整。\n\n---\n*Gate 1 PRD Review | Issue #19*",
+  "agent": "architect",
+  "source_comment_url": "",
+  "created_at": "2026-04-22T13:56:07Z",
+  "status": "pending"
+}

--- a/.claude/results/comment_19_20260422_135655.json
+++ b/.claude/results/comment_19_20260422_135655.json
@@ -1,0 +1,9 @@
+{
+  "type": "issue-comment",
+  "issue_number": 19,
+  "body": "**Agent**: qa-engineer\n**Date**: 2026-04-22T13:56:55Z\n**Source**: [Issue #19 Comment]()\n---\n\n## Gate 1 PRD Review — QA 签字结论\n\n**角色**: QA  \n**PRD 版本**: v2.0  \n**PRD 路径**: `docs/prd/019_installation_script_doc_path_2026-04-22.md`  \n\n---\n\n### 整体 verdict: **Conditional Approved**\n\n### 逐项确认\n\n| 评审项 | 结论 |\n|--------|------|\n| 六类产物范围 | 接受 |\n| 关键入口真实读取 | 可测试 |\n| 成功判据 | 可执行（8项全部明确） |\n| #30 吸收完整性 | 完整 |\n| 范围边界与 non-goals | 清晰完整 |\n\n### 新增交付域评估（PRD v2.0 相较 v1.0）\n\n| 新增项 | 可测试性 | 评价 |\n|--------|---------|------|\n| 4.5 逐层依赖分析 + AC-7.7 | 可测试 | 产出物明确（矩阵 + 最小打包目录集），6项检查清单可逐项核对 |\n| 4.6 打包目录规则 + AC-7.8 | 可测试 | 准入4条 + 准出4条 + 审批流程，pass/fail 清晰 |\n| 4.7 CLAUDE.md 规则沉淀 + AC-7.9 | 可测试 | 5项规则可逐项对照验证 |\n\n### Conditional 条件\n\n1. **Tech Spec 补充完备性检查输出格式**：AC-7.4 \\\"检查结果可供 QA 复核\\\" 需明确输出格式（stdout / log / JSON）和存放位置，以便 QA 设计自动化验证 case。\n2. **Tech Spec 定义关键入口最小验证集**：AC-7.5 \\\"至少一个\\\" 需定义最小验证集（如：至少一个 PM skill + 至少一个 workflow + 至少一个 template），避免测试 coverage 漂移。\n\n### 签字\n\n**QA[✅] Conditional Approved**\n\n理由：PRD v2.0 完整回应了 Human comment 的两个核心交付域（逐层依赖分析、CLAUDE.md 规则沉淀）。新增 AC-7.7~7.9 可测试性强，范围边界和 non-goals 完整。两项 conditional 条件为 Tech Spec 阶段补充建议，非 PRD 阻塞项。",
+  "agent": "qa-engineer",
+  "source_comment_url": "",
+  "created_at": "2026-04-22T13:56:55Z",
+  "status": "pending"
+}

--- a/.claude/results/comment_21_20260422_040139.json
+++ b/.claude/results/comment_21_20260422_040139.json
@@ -5,5 +5,6 @@
   "agent": "product-manager",
   "source_comment_url": "",
   "created_at": "2026-04-22T04:01:39Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/.claude/results/comment_30_20260422_035708.json
+++ b/.claude/results/comment_30_20260422_035708.json
@@ -5,5 +5,6 @@
   "agent": "product-manager",
   "source_comment_url": "",
   "created_at": "2026-04-22T03:57:08Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/.claude/results/comment_30_20260422_091806.json
+++ b/.claude/results/comment_30_20260422_091806.json
@@ -5,5 +5,6 @@
   "agent": "github-actions[sync]",
   "source_comment_url": "",
   "created_at": "2026-04-22T09:18:06Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/.claude/results/comment_5_20260422_032111.json
+++ b/.claude/results/comment_5_20260422_032111.json
@@ -5,5 +5,6 @@
   "agent": "product-manager",
   "source_comment_url": "",
   "created_at": "2026-04-22T03:21:11Z",
-  "status": "pending"
+  "status": "sent",
+  "http_code": 201
 }

--- a/docs/prd/019_installation_script_doc_path_2026-04-22.md
+++ b/docs/prd/019_installation_script_doc_path_2026-04-22.md
@@ -1,0 +1,287 @@
+---
+name: 安装脚本安装结果完备性与路径映射
+description: 定义 Issue #19 的当前有效 PRD，唯一主线为安装脚本执行后的整体安装完备性验证，覆盖路径映射、引用解析、真实入口读取与 fallback 行为，并吸收 #30 的有效范围
+status: Approved
+owner: Product Manager
+date: 2026-04-22
+update_date: 2026-04-22
+issue: "#19"
+---
+
+# PRD #019 — 安装脚本安装结果完备性与路径映射
+
+## 1. 背景
+
+Issue #19 的当前有效问题不再只是安装后文档路径失效，而是 AgentDevFlow 安装到 `~/.claude/` 后，是否形成了**完整、可读取、可解析、可告警**的安装结果。用户最新明确要求：#19 必须以“安装脚本执行后整个安装内容的完备性测试”为唯一主线推进。
+
+同时，Issue #30 中关于 `skills/*/SKILL.md`、`skills/workflows/*.md`、`skills/shared/*`、`skills/templates/*` 在安装后因开发态硬编码路径而失效的问题，经核对后属于 #19 的同一主问题范围，需作为有效输入吸收到 #19，而不再独立推进。
+
+## 2. 问题
+
+当前需要被统一解决和验证的问题包括：
+
+- 安装后 `prompts/`、`docs/` 是否完整复制到 `~/.claude/AgentDevFlow/`
+- 安装后稳定版 skill namespace 是否正确落到 `~/.claude/skills/`，且**不要求 `adf-` 前缀**
+- `skills/*/SKILL.md`、`skills/workflows/*.md`、`skills/shared/*`、`skills/templates/*` 中的引用是否仍依赖开发目录相对路径
+- `${ADF_DOC_ROOT}` 是否被正确注入、更新、fallback，并用于文档路径解析
+- 缺失/错误路径场景下，系统是否能显式暴露安装不完整，而不是输出模糊“安装成功”
+- 关键入口是否能真实读取目标内容，而非仅停留在静态路径存在性检查
+
+## 3. 目标
+
+形成 #19 的当前有效产品层需求定义，明确：
+
+1. #19 是安装脚本安装后内容完备性验证的**唯一主线**
+2. 安装后需同时覆盖 docs/prompts/skills/workflows/shared/templates 六类产物完整性
+3. 安装后所有关键引用必须能解析到 `~/.claude/AgentDevFlow/` 或 `~/.claude/skills/` 的稳定路径
+4. `${ADF_DOC_ROOT}` 生命周期与 fallback 行为必须明确且可验证
+5. 缺失场景必须输出明确告警与修复建议，不得掩盖安装不完整状态
+6. #30 的有效范围必须并入 #19，不再独立形成 PRD / Tech / QA / Gate 推进链
+
+## 4. 范围
+
+### 4.1 安装结果完备性范围
+
+必须检查并验证以下安装产物：
+
+- `~/.claude/AgentDevFlow/prompts/`
+- `~/.claude/AgentDevFlow/docs/`
+- `~/.claude/skills/` 下稳定版 skill 目录与 `SKILL.md`
+- `~/.claude/skills/workflows/`
+- `~/.claude/skills/shared/`
+- `~/.claude/skills/templates/`
+- shell profile 中 `${ADF_DOC_ROOT}` 注入项
+
+#### 4.1.1 "关键文件"判定标准
+
+PRD 中多次出现"关键 prompts/docs/skill files"，为避免歧义，定义判定标准如下：
+
+**关键文件判定标准**（满足至少一项即视为关键）：
+1. 被至少一个核心 skill（start-agent-team, team-setup, product-manager, architect, qa-engineer, engineer, platform-sre, pmo, agent-bootstrap）的**必读文档列表**直接引用
+2. 被 workflow 文件交叉引用且影响流程执行（如 prd-review.md 引用 tech-review.md 的评审规则）
+3. 被 scripts/ 中核心脚本（github_issue_sync.py, task_router.py 等）依赖且无法在安装后重新生成
+4. 属于共享协议或基础设施文档，缺失会导致角色初始化失败（如 skill-protocol.md, event-bus.md）
+5. 属于治理或运营基础设施，被 PMO 或 Team Lead 工作流程直接依赖（如 docs/governance/core-principles.md）
+
+**非关键文件**（不满足完备性检查硬性要求，但建议包含）：
+- 项目历史交付物（如已完成的 PRD、Tech Spec、QA Report）——安装脚本只打包框架和模板，不打包项目历史
+- 仅用于开发测试的文件
+- 安装后可重新生成的运行时产物
+
+**说明**：具体的"最小完整关键文件清单"由 §4.5 逐层依赖分析产出，列入 Tech Spec。PRD 只定义判定标准，不罗列具体文件清单。
+
+### 4.2 引用解析范围
+
+必须覆盖以下安装后真实可达性：
+
+- skill → prompts/docs
+- skill → workflows
+- skill → shared
+- skill → templates
+- 其他安装后仍依赖仓库根目录相对路径的引用
+
+### 4.3 关键入口读取范围
+
+至少验证三类真实入口：
+
+- 角色 SKILL 必读文档入口
+- workflow 文档入口
+- template 文档入口
+
+要求验证“可真实读取目标内容”，而不是仅验证文件存在。
+
+### 4.4 与 #30 的关系
+
+- #19：当前唯一主线，负责安装脚本执行后的整体安装完备性验证
+- #30：重复 issue，仅保留为背景/补充分析留档
+- #30 中关于 `skills/workflows/shared/templates` 路径失效、稳定版 skill namespace、运行时 fallback、职责边界等有效内容，必须吸收到 #19 当前交付
+- 后续正式评审、实现、QA 与 comment 统一以 #19 为准，不再发布 #30 独立 Gate 2 / QA 结论
+
+### 4.5 逐层依赖分析范围
+
+安装脚本的打包目录清单不能仅由直觉列出，而必须从入口 skill 开始逐层分析文件依赖，确定"哪些目录被引用、哪些目录必须打包"。
+
+**分析起点**：`skills/start-agent-team/SKILL.md`
+
+**分析范围**：
+1. 从 start-agent-team 开始，逐层向下分析每个被引用的 skill（team-setup, product-manager, architect, qa-engineer, engineer, platform-sre, pmo, agent-bootstrap 等）对文件系统的依赖
+2. 分析每个 skill 引用的 prompts/、docs/、skills/workflows/、skills/shared/、skills/templates/、scripts/ 等目录中的具体文件
+3. 分析 workflow 文件之间的交叉引用（如 prd-review.md 引用 tech-review.md 等）
+4. 分析 scripts/ 目录中被 skill 直接调用的脚本（如 github_issue_sync.py, task_router.py）
+5. 分析 docs/governance/、docs/todo/、docs/memo/ 等治理和运营目录的依赖关系
+6. 产出**依赖分析矩阵**：每行一个 skill/workflow，每列一个目录类别，标记依赖强度（必须/可选/无）
+
+**分析产出要求**：
+- 依赖分析矩阵文档（`docs/tech/019_dependency_matrix.md` 或 Tech Spec 内嵌）
+- 基于依赖矩阵得出"最小必要打包目录集"
+- 明确哪些目录属于"必须打包"、哪些属于"可选打包"、哪些属于"运行时生成"（不应打包）
+
+**边界**：具体的依赖分析执行由 Architect 在 Tech Spec 中完成，PRD 只定义分析范围和产出要求。
+
+### 4.6 打包目录准入/准出规则
+
+基于逐层依赖分析结果，定义打包目录的准入和准出规则，避免无限制增加目录依赖。
+
+**准入规则**（新增目录必须满足至少一项）：
+1. 被至少一个核心 skill（start-agent-team, team-setup, product-manager, architect, qa-engineer, engineer）直接引用
+2. 被 workflow 文件交叉引用且影响流程执行
+3. 被 scripts/ 中核心脚本依赖且无法在安装后重新生成
+4. 属于治理或运营基础设施，缺失会导致角色初始化失败（如 docs/governance/core-principles.md）
+
+**准出规则**（以下目录不应打包）：
+1. 运行时生成的目录（如 `.claude/logs/`、`.claude/teams/`、`.claude/task_queue/`）
+2. 项目特定交付产物（如 `docs/prd/` 中已完成的 PRD 文件）——安装脚本只打包框架和模板，不打包项目历史交付物
+3. 开发态自举产物（如 `.claude/skills/adf-*`）
+4. 平台适配层中仅用于开发测试的文件
+
+**审批流程**：
+- 新增目录纳入打包范围必须经过 Tech Review（Architect 评估必要性）
+- 新增目录必须同步更新 CLAUDE.md 中的目录清单
+- 新增目录必须同步更新安装脚本的复制逻辑和完备性检查清单
+
+### 4.7 CLAUDE.md 规则沉淀
+
+将打包目录规则和禁止无限制增加目录依赖的治理要求沉淀到本项目的 `CLAUDE.md` 中。
+
+**必须沉淀的规则**：
+1. **打包目录清单**：明确列出安装脚本必须打包的目录和文件清单，以及每个目录的准入理由
+2. **目录依赖变更规则**：新增目录依赖必须经过 Architect 评估 + Tech Review 签字
+3. **开发态 vs 安装态区分**：明确哪些目录属于开发态（如 `.claude/skills/adf-*`）、哪些属于安装态（如 `~/.claude/skills/`），禁止混淆
+4. **引用路径规范**：skill 中引用文件必须使用 `${ADF_DOC_ROOT}` 或稳定版 skill 路径，禁止硬编码开发目录相对路径
+5. **安装脚本更新同步规则**：任何新增目录依赖必须同步更新安装脚本的复制逻辑 + 完备性检查 + 安装说明
+
+**产出要求**：
+- `CLAUDE.md` 中新增"安装目录打包规则"章节
+- 规则必须与 PRD 中的准入/准出规则一致
+- 规则必须包含具体目录清单和变更审批流程
+
+## 5. 非目标
+
+- 不在本 PRD 中直接提交实现 diff
+- 不要求在 Gate 1 阶段给出所有脚本实现细节
+- 不把本仓开发态 `.claude/skills/adf-*` 自举机制误当作外部安装态要求
+- 不保留 #30 的独立推进链路或独立验收口径
+- 逐层依赖分析的具体执行细节（如每行矩阵内容）不在 PRD 中产出，由 Architect 在 Tech Spec 中完成
+- CLAUDE.md 规则沉淀的具体文案不在 PRD 中产出，由 Engineer 在实现阶段完成，PRD 只定义规则范围和准入/准出标准
+- 不覆盖运行时生成目录（如 `.claude/logs/`、`.claude/teams/`）的打包策略，这些目录属于安装后运行时产物
+
+## 6. 用户故事
+
+### US-1：安装使用者
+> 作为安装 AgentDevFlow 的用户，我希望安装后整个内容集是完整的，所有关键引用都能解析，关键入口都能真实读取，而不是遇到失效路径后再手工修补。
+
+### US-2：维护者
+> 作为维护者，我希望 docs/prompts/skills/workflows/shared/templates 的安装结果、路径模型、环境变量与 fallback 行为都有统一标准，这样后续修复不会出现双主线和重复补丁。
+
+## 7. 验收标准
+
+### 7.1 路径映射规则
+
+- [ ] 已明确 `prompts/ -> ~/.claude/AgentDevFlow/prompts/`
+- [ ] 已明确 `docs/ -> ~/.claude/AgentDevFlow/docs/`
+- [ ] 已明确稳定版 skill 路径落到 `~/.claude/skills/`，安装态不要求 `adf-` 前缀
+- [ ] 已明确 workflows/shared/templates 的稳定安装路径
+
+### 7.2 安装后引用仍有效
+
+- [ ] skill 对 prompts/docs 的引用可通过 `${ADF_DOC_ROOT}` 或默认 fallback 解析
+- [ ] skill 对 workflows/shared/templates 的引用在安装态可解析
+- [ ] 不再依赖开发目录相对路径
+
+### 7.3 fallback 行为
+
+- [ ] `${ADF_DOC_ROOT}` 缺失时可 fallback 到 `${HOME}/.claude/AgentDevFlow`
+- [ ] 缺失/错误路径时输出明确缺失项、修复建议与安装不完整提示
+- [ ] 不因单个引用缺失阻断 Issue / Gate / PR 核心流程，但不得隐瞒失败状态
+
+### 7.4 安装脚本自动映射与完备性检查
+
+- [ ] 安装脚本完成后自动检查 docs/prompts/skills/workflows/shared/templates 六类产物
+- [ ] 安装完成仅在关键产物存在、关键引用可解析、`${ADF_DOC_ROOT}` 可用时才可宣称“安装完整”
+- [ ] 完备性检查结果可供 QA 复核，不得只给出模糊成功提示
+
+### 7.5 关键入口真实读取
+
+- [ ] 至少一个角色 SKILL 入口可读取目标文档
+- [ ] 至少一个 workflow 入口可读取目标文档
+- [ ] 至少一个 template 入口可读取目标文档
+
+### 7.6 流程与边界
+
+- [ ] 本 issue 已按严格研发交付流程作为唯一主线重新进入 Gate 1
+- [ ] 已明确 #30 仅作 duplicate/background，不再独立推进
+
+### 7.7 逐层依赖分析覆盖率（新增）
+
+- [ ] 已从 `skills/start-agent-team/SKILL.md` 开始完成逐层依赖分析
+- [ ] 依赖分析覆盖所有核心 skill（start-agent-team, team-setup, product-manager, architect, qa-engineer, engineer, platform-sre, pmo, agent-bootstrap）
+- [ ] 依赖分析覆盖所有 workflow 文件的交叉引用
+- [ ] 依赖分析覆盖 scripts/ 中被 skill 直接调用的核心脚本
+- [ ] 已产出依赖分析矩阵，明确每行（skill/workflow）对每列（目录类别）的依赖强度
+- [ ] 基于依赖矩阵确定了"最小必要打包目录集"
+
+### 7.8 打包目录规则完整性（新增）
+
+- [ ] 已定义打包目录准入规则（新增目录必须满足的条件）
+- [ ] 已定义打包目录准出规则（哪些目录不应打包）
+- [ ] 已定义新增目录审批流程（Tech Review 评估 + 同步更新安装脚本 + 同步更新 CLAUDE.md）
+- [ ] 准入/准出规则与依赖分析矩阵结论一致
+
+### 7.9 CLAUDE.md 规则沉淀完整性（新增）
+
+- [ ] `CLAUDE.md` 中已新增"安装目录打包规则"章节
+- [ ] 规则章节包含打包目录清单及每个目录的准入理由
+- [ ] 规则章节包含目录依赖变更规则（新增目录需 Architect 评估 + Tech Review 签字）
+- [ ] 规则章节包含开发态 vs 安装态区分说明
+- [ ] 规则章节包含引用路径规范（`${ADF_DOC_ROOT}` 使用要求）
+- [ ] 规则章节包含安装脚本更新同步规则
+
+## 8. 成功判据
+
+仅当以下条件同时满足时，才可宣称 #19 方案闭环：
+
+1. `~/.claude/AgentDevFlow/` 下 prompts/docs 存在且关键文件可读
+2. `~/.claude/skills/` 下稳定版 skill / workflows / shared / templates 存在且关键文件可读
+3. `${ADF_DOC_ROOT}` 已被注入并可用于文档解析
+4. 三类关键入口可真实读取目标内容
+5. 缺失场景下输出明确告警，且不会错误宣称安装成功
+6. **逐层依赖分析已完成，依赖矩阵已产出，最小必要打包目录集已确定**
+7. **打包目录准入/准出规则已定义，新增目录审批流程已明确**
+8. **`CLAUDE.md` 中已沉淀安装目录打包规则，且规则与 PRD 一致**
+
+## 9. 风险
+
+| 风险 | 影响 | 缓解 |
+|------|------|------|
+| 只检查 docs/prompts，遗漏 skills/workflows/shared/templates | 高 | 将六类产物纳入统一完备性检查清单 |
+| 误把 `adf-` 前缀当作安装态要求 | 高 | 在 PRD/Tech/QA 中显式区分开发态自举与外部安装态 |
+| 仅验证路径存在，未验证真实读取 | 高 | 增加三类关键入口读取验收项 |
+| #19 / #30 双主线再次漂移 | 高 | 明确 #19 为唯一主线，#30 仅留背景，不再独立推进 |
+| 逐层依赖分析遗漏 scripts/、docs/governance/ 等目录 | 高 | 明确分析范围包含所有被核心 skill 引用的目录，产出依赖矩阵逐项核对 |
+| CLAUDE.md 规则与实际安装脚本不一致 | 高 | 规则更新与安装脚本修改同步进行，QA 验证两者一致性 |
+| 新增目录无审批流程导致打包范围膨胀 | 中 | 定义准入/准出规则和审批流程，Tech Review 必须评估新增目录必要性 |
+
+## 10. 依赖
+
+- 当前安装脚本 `scripts/install.sh`
+- 当前 `skills/` 源文件中的路径引用现状
+- `docs/tech/019_installation_script_doc_path_tech_2026-04-22.md`
+- `docs/qa/019_installation_script_doc_path_qa_2026-04-22.md`
+- Issue #30 的有效背景输入（仅供吸收，不作独立交付依据）
+
+## 11. 评审记录
+
+| 日期 | 评审人 | 备注 | 决策 |
+|---|---|---|---|
+| 2026-04-22 | PM | 按用户最新纠正重建 #19 当前有效 PRD：统一为安装后整体完备性验证主线，并吸收 #30 有效范围 | Draft |
+| 2026-04-22 | PM | **重大变更回滚**：Human comment #19#issuecomment-4296509380 指出 PRD 未覆盖逐层依赖分析和 CLAUDE.md 规则沉淀；PM 评估确认两个交付域缺失；按重大变更回滚到 Gate 1，产出 PRD v2.0 | 回滚至 Gate 1 |
+| 2026-04-22 | PM | Gate 1 v2.0 评审 — PRD v2.0 需求口径确认：问题陈述明确、范围边界完整、非目标已声明、验收标准 9 项覆盖充分、4.1.1 "关键文件"判定标准已补充 | ✅ Approved |
+| 2026-04-22 | Architect | Gate 1 v2.0 评审 — 技术可行性确认：PRD v2.0 范围边界清晰、逐层依赖分析范围合理、准入/准出规则技术可落地；Conditional 条件 1（"关键文件"定义）已由 4.1.1 补充满足；条件 2（bootstrap-sync 协同）defer 到 Tech Spec | ✅ Approved |
+| 2026-04-22 | QA | Gate 1 v2.0 评审 — 验收标准可测试性确认：9 项验收标准均可测试、关键入口真实读取验证方法可行、缺失场景可模拟；QA 签字为 Conditional：待 Tech Spec 中确认"关键文件"最小清单和 bootstrap-sync 协同机制的具体实现 | ✅ Conditional Approved |
+
+## 12. 版本历史
+
+| 版本 | 日期 | 变更说明 | 变更人 |
+|------|------|---------|-------|
+| v1.0 | 2026-04-22 | 初始版本：安装后整体完备性验证主线，六类产物 + 引用解析 + fallback | PM |
+| v2.0 | 2026-04-22 | 重大变更：新增 4.5 逐层依赖分析范围、4.6 打包目录准入/准出规则、4.7 CLAUDE.md 规则沉淀；新增 4.1.1 "关键文件"判定标准（回应 Architect Conditional 条件）；新增 7.7-7.9 验收标准；更新 8. 成功判据；新增风险项 | PM |

--- a/docs/qa/019_installation_script_doc_path_qa_2026-04-22.md
+++ b/docs/qa/019_installation_script_doc_path_qa_2026-04-22.md
@@ -1,0 +1,291 @@
+---
+name: 安装脚本安装结果完备性与路径映射 — QA Case Design v2.0
+description: 基于 PRD #019 v2.0 与 Tech-19_v2.0 的当前有效 QA Case Design，定义安装脚本执行后的全量安装结果、逐层依赖分析、打包目录规则、引用解析、完备性检查与 fallback 行为的验证用例
+status: Approved
+owner: QA Engineer
+date: 2026-04-22
+update_date: 2026-04-22
+issue: "#19"
+prd: docs/prd/019_installation_script_doc_path_2026-04-22.md
+tech: docs/tech/019_installation_script_doc_path_tech_2026-04-22.md
+---
+
+# QA Case Design #019 — 安装脚本安装结果完备性与路径映射
+
+---
+
+## 当前有效状态
+
+- **当前有效版本**：v2.0 Approved
+- **当前有效输入**：PRD #019 v2.0（Gate 1 Approved）+ Tech Spec #019 v2.0（Gate 2 Approved）
+- **当前阶段**：QA Case Design（PM + Architect + Engineer 三方评审完成）
+- **规则说明**：本文件为 Issue #19 的当前有效 QA Case Design，覆盖安装脚本执行后的全量安装结果完备性测试，并吸收 #30 的有效测试关注点
+- **范围收口说明**：Issue #30 已确认为与 #19 同问题的 duplicate background，其有效测试关注点已回并至本 QA Case；后续不再单独为 #30 建立独立 QA 交付链
+
+## 追溯关系
+
+- **PRD**: `docs/prd/019_installation_script_doc_path_2026-04-22.md`
+- **Tech Spec**: `docs/tech/019_installation_script_doc_path_tech_2026-04-22.md`
+
+### PRD #019 → QA Case 追溯矩阵
+
+| PRD Section | 对应 TC | 覆盖状态 |
+|-------------|---------|---------|
+| 7.1 路径映射规则 | TC-19-01, TC-19-02 | ✅ |
+| 7.2 安装后引用仍有效 | TC-19-03, TC-19-09 | ✅ |
+| 7.3 fallback 行为 | TC-19-10, TC-19-11 | ✅ |
+| 7.4 安装脚本自动映射与完备性检查 | TC-19-05, TC-19-06, TC-19-07 | ✅ |
+| 7.5 关键入口真实读取 | TC-19-08, TC-19-09 | ✅ |
+| 7.6 流程与边界 | TC-19-12 | ✅ |
+| 7.7 逐层依赖分析覆盖率 | TC-19-13, TC-19-14 | ✅ |
+| 7.8 打包目录规则完整性 | TC-19-14 | ✅ |
+| 7.9 CLAUDE.md 规则沉淀完整性 | TC-19-15 | ✅ |
+
+### Tech Spec #019 → QA Case 追溯矩阵
+
+| Tech Spec Section | 对应 TC | 覆盖状态 |
+|-------------------|---------|---------|
+| 1. 路径映射规则 | TC-19-01, TC-19-02, TC-19-09 | ✅ |
+| 2. 逐层依赖分析 | TC-19-13, TC-19-14 | ✅ |
+| 3. Skill 引用适配 | TC-19-03, TC-19-09 | ✅ |
+| 4. ADF_DOC_ROOT 生命周期 | TC-19-04 | ✅ |
+| 5. 完备性检查机制 | TC-19-05, TC-19-06, TC-19-07, TC-19-08 | ✅ |
+| 6. Fallback 行为 | TC-19-10, TC-19-11 | ✅ |
+| 7. 安装脚本更新范围 | TC-19-02, TC-19-05, TC-19-14 | ✅ |
+| 8. Bootstrap-Sync 协同机制 | TC-19-12 | ✅ |
+| 9. CLAUDE.md 规则沉淀 | TC-19-15 | ✅ |
+
+---
+
+## TC-19-01：安装目录路径映射规则验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-01 |
+| 标题 | 安装目录路径映射规则验证 |
+| 追溯 | PRD 7.1；Tech 1 |
+| 前置条件 | 安装脚本与说明文档已更新 |
+| 测试步骤 | 检查是否明确存在 `prompts/ -> ~/.claude/AgentDevFlow/prompts/`、`docs/ -> ~/.claude/AgentDevFlow/docs/`、`skills/* -> ~/.claude/skills/`、`skills/workflows/`、`skills/shared/`、`skills/templates/` 的稳定版安装态路径映射关系 |
+| 预期结果 | 六类路径映射规则明确，安装态 skill 路径不依赖 adf-prefix 假设，文档与 skill 安装路径职责清晰 |
+| 验证方法 | 文档内容验证 |
+| 优先级 | P1 |
+
+## TC-19-02：六类安装产物完备性验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-02 |
+| 标题 | 六类安装产物完备性验证 |
+| 追溯 | PRD 7.1, 7.4；Tech 1, 5 |
+| 前置条件 | 已执行完整安装脚本 |
+| 测试步骤 | 对照检查清单核对 `prompts/`、`docs/`、stable skills、`workflows/`、`shared/`、`templates/`、`scripts/` 与 `ADF_DOC_ROOT` 注入项 |
+| 预期结果 | 六类产物与核心脚本均完整落位；shared 至少存在目录或占位文件；无安装态 `adf-*` 命名空间残留 |
+| 验证方法 | 安装后文件系统验证 |
+| 优先级 | P0 |
+
+## TC-19-03：安装后引用解析验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-03 |
+| 标题 | 安装后引用解析验证 |
+| 追溯 | PRD 7.2；Tech 3 |
+| 前置条件 | skill 文档引用已更新 |
+| 测试步骤 | 抽查 skill 中 docs/prompts/workflows/shared/templates/scripts 引用，验证安装后均能解析到 `~/.claude/AgentDevFlow/` 或 `~/.claude/skills/` 稳定路径 |
+| 预期结果 | 所有关键引用可解析；不再依赖开发目录相对路径 |
+| 验证方法 | 文档搜索 + 安装后解析验证 |
+| 优先级 | P0 |
+
+## TC-19-04：ADF_DOC_ROOT 注入与生命周期验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-04 |
+| 标题 | ADF_DOC_ROOT 注入与生命周期验证 |
+| 追溯 | Tech 4 |
+| 前置条件 | 安装脚本支持首次安装、更新、卸载 |
+| 测试步骤 | 验证首次安装写入、更新替换、运行时 fallback、卸载清理逻辑 |
+| 预期结果 | ADF_DOC_ROOT 生命周期行为与 Tech 描述一致 |
+| 验证方法 | 安装脚本行为验证 |
+| 优先级 | P1 |
+
+## TC-19-05：完备性检查对象覆盖验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-05 |
+| 标题 | 完备性检查对象覆盖验证 |
+| 追溯 | PRD 7.4；Tech 5.1 |
+| 前置条件 | 已执行安装脚本 |
+| 测试步骤 | 校验检查对象是否覆盖 prompts、docs/governance、docs/platforms、stable skills、workflows、shared、templates、scripts、环境变量 |
+| 预期结果 | 完备性检查对象与 PRD/Tech 要求一致，无 shared 遗漏 |
+| 验证方法 | JSON 输出 + 日志文件校验 |
+| 优先级 | P0 |
+
+## TC-19-06：JSON 输出与 .install-check.log 校验
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-06 |
+| 标题 | JSON 输出与 .install-check.log 校验 |
+| 追溯 | PRD 7.4；Tech 5.2 |
+| 前置条件 | 完备性检查已执行 |
+| 测试步骤 | 读取 stdout JSON 与 `~/.claude/AgentDevFlow/.install-check.log`，核对 `check_version`、`overall_status`、`checks`、`missing_summary`、`recommendation` 字段；确认 shared 状态支持 `pass/fail/warn`，其中空目录/仅占位文件通过 `warn + details` 表达 |
+| 预期结果 | 输出结构化、字段完整、日志落盘正确、可供 QA 复核；shared 空能力位以 `warn` 呈现而非独立 `empty` 枚举 |
+| 验证方法 | JSON 结构校验 + 日志文件校验 |
+| 优先级 | P0 |
+
+## TC-19-07：成功判据与失败边界验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-07 |
+| 标题 | 成功判据与失败边界验证 |
+| 追溯 | PRD 7.4；Tech 5.3, 5.4 |
+| 前置条件 | 可执行完整安装与异常安装场景 |
+| 测试步骤 | 分别在完整安装与缺失项场景下运行检查，验证 `overall_status`、缺失分类、重装建议与“不隐瞒失败状态”要求 |
+| 预期结果 | 仅在全部条件满足时宣称安装完整；异常场景输出明确告警与建议 |
+| 验证方法 | 正常/异常场景对比验证 |
+| 优先级 | P0 |
+
+## TC-19-08：关键入口最小验证集执行
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-08 |
+| 标题 | 关键入口最小验证集执行 |
+| 追溯 | PRD 7.5；Tech 5.5 |
+| 前置条件 | 已执行安装脚本并完成环境变量注入 |
+| 测试步骤 | 分别验证：1）PM Skill → `prompts/002_develop_pipeline.md`；2）`skills/workflows/tech-review.md`；3）`~/.claude/skills/shared/` 目录或占位文件；4）`skills/templates/prd-template.md` |
+| 预期结果 | 四类关键入口均可真实读取或被正确检测，不仅停留在静态路径存在 |
+| 验证方法 | 实际入口读取验证 |
+| 优先级 | P0 |
+
+## TC-19-09：六类关键入口扩展验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-09 |
+| 标题 | 六类关键入口扩展验证 |
+| 追溯 | PRD 7.2, 7.5；Tech 1, 3, 5.5 |
+| 前置条件 | 安装完成 |
+| 测试步骤 | 分别抽查 docs / prompts / skills / workflows / shared / templates 的代表性入口，验证可读性与落点职责 |
+| 预期结果 | 六类关键入口均可在安装态访问，职责边界清晰 |
+| 验证方法 | 安装后路径解析与读取验证 |
+| 优先级 | P0 |
+
+## TC-19-10：缺失路径 fallback 验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-10 |
+| 标题 | 缺失路径 fallback 验证 |
+| 追溯 | PRD 7.3；Tech 6 |
+| 前置条件 | 模拟 docs/prompts/workflows/shared/templates 任一缺失 |
+| 测试步骤 | 制造缺失路径并触发 skill 读取逻辑，观察 fallback、提示与流程行为 |
+| 预期结果 | 系统输出明确缺失路径与修复建议；不阻断核心流程；不隐瞒安装缺失 |
+| 验证方法 | 异常场景验证 |
+| 优先级 | P0 |
+
+## TC-19-11：错误路径与命名空间错误验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-11 |
+| 标题 | 错误路径与命名空间错误验证 |
+| 追溯 | PRD 7.3；Tech 5.4, 6 |
+| 前置条件 | 模拟错误路径或安装态 `adf-*` 残留 |
+| 测试步骤 | 制造 stable skill 路径错误、错误 fallback 或 `adf-*` 命名空间残留，执行检查与读取 |
+| 预期结果 | 系统将其判定为路径模型错误/安装不完整，并输出明确告警 |
+| 验证方法 | 异常场景验证 |
+| 优先级 | P0 |
+
+## TC-19-12：流程边界与 bootstrap-sync 协同验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-12 |
+| 标题 | 流程边界与 bootstrap-sync 协同验证 |
+| 追溯 | PRD 7.6；Tech 8 |
+| 前置条件 | bootstrap-sync 与安装脚本协同逻辑已实现 |
+| 测试步骤 | 验证 bootstrap-sync 仅作用于开发态 `.claude/skills/adf-*`，不触碰安装态目录；验证 #19 / #30 主线收口与告警逻辑 |
+| 预期结果 | 边界清晰，#30 不形成独立 QA 主线，安装态与开发态不混淆 |
+| 验证方法 | 文档 + 行为校验 |
+| 优先级 | P1 |
+
+## TC-19-13：逐层依赖分析结果验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-13 |
+| 标题 | 逐层依赖分析结果验证 |
+| 追溯 | PRD 7.7；Tech 2.1, 2.2 |
+| 前置条件 | 依赖矩阵已产出 |
+| 测试步骤 | 复核 start-agent-team 起点、10 个 skill 覆盖、Engineer / Platform-SRE / agent-bootstrap 展开说明、shared 独立安装类别说明 |
+| 预期结果 | 依赖矩阵覆盖所有核心 skill，未再 defer，shared 被纳入独立安装类别 |
+| 验证方法 | 文档内容验证 |
+| 优先级 | P0 |
+
+## TC-19-14：最小必要打包目录集与安装脚本覆盖验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-14 |
+| 标题 | 最小必要打包目录集与安装脚本覆盖验证 |
+| 追溯 | PRD 7.7, 7.8；Tech 2.3-2.9, 7 |
+| 前置条件 | 打包目录规则与安装脚本已更新 |
+| 测试步骤 | 验证最小必要打包目录集是否覆盖 prompts/docs/governance/platforms/skills/workflows/shared/templates/scripts/README；验证不应打包目录未被错误复制 |
+| 预期结果 | 打包目录准入/准出规则与依赖矩阵一致，安装脚本覆盖最小必要目录集 |
+| 验证方法 | 文档 + 安装后目录对比验证 |
+| 优先级 | P0 |
+
+## TC-19-15：CLAUDE.md 规则沉淀验证
+
+| 字段 | 内容 |
+|------|------|
+| 用例 ID | TC-19-15 |
+| 标题 | CLAUDE.md 规则沉淀验证 |
+| 追溯 | PRD 7.9；Tech 9 |
+| 前置条件 | CLAUDE.md 已更新 |
+| 测试步骤 | 检查 `CLAUDE.md` 是否新增“安装目录打包规则”章节，并覆盖打包目录清单、目录依赖变更规则、开发态 vs 安装态区分、引用路径规范、安装脚本更新同步规则 |
+| 预期结果 | CLAUDE.md 规则与 PRD/Tech 一致，且与实际安装脚本行为可对齐 |
+| 验证方法 | 文档内容对照验证 |
+| 优先级 | P0 |
+
+---
+
+## 当前评审状态
+
+- **当前状态**：Approved
+- **下一动作**：进入文档 PR / HR#1 前置收敛
+- **评审前提**：以 PRD #019 v2.0 与 Tech Spec #019 v2.0 为准，后续实现与文档修改不得绕过 QA Case 评审
+
+## 成功判据
+
+- 六类安装产物全部落位，且 shared 作为必须存在的安装能力位已落位；当前无共享业务文件时可为空目录/占位文件，并以 `warn + details` 表达
+- 六类关键入口（docs/prompts/skills/workflows/shared/templates）均可在安装态访问
+- JSON 输出与 `.install-check.log` 结构完整、状态准确、可复核
+- 缺失/错误路径场景下输出明确告警与修复建议，且不阻断核心流程
+- 逐层依赖分析覆盖所有核心 skill，最小必要打包目录集被安装脚本完整覆盖
+- CLAUDE.md 中安装目录打包规则与实际安装脚本行为一致
+- #30 仅保留 duplicate/background 追溯语义，不再形成独立 QA 推进或独立放行结论
+
+## v2.0 Draft 变更说明（2026-04-22）
+
+| 变更项 | 说明 |
+|--------|------|
+| 输入升级 | 基于 PRD #019 v2.0 + Tech Spec #019 v2.0 重建 QA Case |
+| 追溯升级 | 追溯矩阵扩展至 PRD 7.1-7.9 与 Tech 1-9 |
+| 新增依赖分析验证 | 新增 TC-19-13 / 14 覆盖逐层依赖分析与打包目录规则 |
+| 新增 shared 验证 | 新增 shared 最小清单、完备性检查与关键入口验证 |
+| 新增输出格式验证 | 新增 TC-19-06 覆盖 JSON 输出与 `.install-check.log` |
+| 新增 CLAUDE.md 验证 | 新增 TC-19-15 覆盖规则沉淀一致性 |
+| 入口范围扩展 | 从三类入口扩展为六类安装类别 + 四类最小验证集 |
+
+## 评审记录
+
+| 日期 | 评审人 | 备注 | 决策 |
+|---|---|---|---|
+| 2026-04-22 | PM | QA Case 最终评审：测试追溯已覆盖 PRD v2.0 / Tech v2.0 当前有效范围，shared 检查口径与 JSON schema 已统一为最终版本，不改变 #19 主线范围，可作为文档 PR / HR#1 前置输入 | ✅ Approved |
+| 2026-04-22 | Architect | QA Case 已完整承接 PRD v2.0 / Tech Spec v2.0，六类产物、JSON 输出、fallback、bootstrap-sync 边界与 CLAUDE.md 规则验证覆盖充分 | ✅ Approved |
+| 2026-04-22 | Engineer | shared 与 JSON schema 口径已统一，不再构成实现或验收阻塞，QA Case 可作为文档 PR / HR#1 前置输入 | ✅ Approved |

--- a/docs/tech/019_installation_script_doc_path_tech_2026-04-22.md
+++ b/docs/tech/019_installation_script_doc_path_tech_2026-04-22.md
@@ -1,0 +1,547 @@
+---
+name: 安装脚本安装结果完备性与路径映射 — Tech Spec v2.0
+description: 基于 PRD #019 v2.0 的当前有效 Tech Spec，定义安装到 ~/.claude/ 后全量安装结果的路径映射、逐层依赖分析、引用解析、完备性检查与 fallback 行为
+status: Approved
+note: "Gate 2 Approved（PM + QA + Engineer 三方签字），Tech Spec 已完成评审收口"
+owner: Architect
+date: 2026-04-22
+update_date: 2026-04-22
+issue: "#19"
+prd: docs/prd/019_installation_script_doc_path_2026-04-22.md
+---
+
+# Tech Spec #019 — 安装脚本安装结果完备性与路径映射（v2.0）
+
+---
+
+**ID**: Tech-19_v2.0
+**状态**: Approved
+**负责人**: Architect
+**日期**: 2026-04-22
+**更新日期**: 2026-04-22
+**基于**: PRD #019 v2.0（Gate 1 Approved, 2026-04-22）
+**当前评审状态**: Gate 2 Approved（PM + QA + Engineer 三签，2026-04-22）
+
+**前提修正**：外部安装态目标路径为 `~/.claude/skills/` 下的稳定版 skill namespace（无 `adf-` 前缀）；`adf-` 前缀仅用于本仓开发态 `.claude/skills/adf-*` 自举隔离。
+
+---
+
+## 上下文
+
+Issue #19 的核心问题是 AgentDevFlow 安装到 `~/.claude/` 后，安装结果是否完整、skill 引用是否能在安装态下真实解析、以及缺失场景是否能被显式暴露。本 Tech Spec 定义全量安装产物的路径映射、逐层依赖分析、打包目录规则、引用解析、完备性检查与 fallback 规则。
+
+**PRD v2.0 重大变更**：新增 §4.5 逐层依赖分析、§4.6 打包目录准入/准出规则、§4.7 CLAUDE.md 规则沉淀。
+
+---
+
+## 1. 路径映射规则
+
+### 1.1 安装态路径映射
+
+| 开发目录 | 安装目录 | 映射规则 | 准入类型 |
+|---|---|---|---|
+| `prompts/` | `~/.claude/AgentDevFlow/prompts/` | 安装时复制 prompts 到安装目录 | 必须 |
+| `docs/` | `~/.claude/AgentDevFlow/docs/` | 安装时复制 docs 到安装目录 | 必须 |
+| `docs/governance/` | `~/.claude/AgentDevFlow/docs/governance/` | 安装时复制 governance 到安装目录 | 必须 |
+| `skills/*/SKILL.md` | `~/.claude/skills/<stable-skill>/SKILL.md` | 安装时复制到稳定版 skill namespace（无 `adf-` 前缀） | 必须 |
+| `skills/workflows/` | `~/.claude/skills/workflows/` | 安装时复制 workflows 到稳定路径 | 必须 |
+| `skills/shared/` | `~/.claude/skills/shared/` | 安装时必须创建 shared 安装能力位；当前无共享资产时可为空目录或占位文件 | 必须 |
+| `skills/templates/` | `~/.claude/skills/templates/` | 安装时复制 templates 到稳定路径 | 必须 |
+| `scripts/` | `~/.claude/AgentDevFlow/scripts/` | 安装时复制 scripts 到安装目录 | 必须 |
+
+**路径隔离原则**：文档安装目录独立于 skill namespace；外部安装态统一使用稳定版 skill namespace（无 `adf-` 前缀），避免与本仓开发态 `.claude/skills/adf-*` 自举产物混淆。
+
+### 1.2 安装态路径适配范围
+
+本 Tech Spec 覆盖安装后 skill 对以下路径的可达性：
+
+- `skills/*/SKILL.md` 中的必读文档引用（prompts/ + docs/ + skills/workflows/ + skills/shared/ + skills/templates/）
+- `skills/workflows/*.md` 中的交叉引用
+- skill 中对 `scripts/` 下脚本的调用引用
+- skill 中对 `docs/governance/` 下治理文档的引用
+- 增强层文档 `docs/platforms/enhancement-layer.md` 的引用（当前为开发目录相对路径，需处理）
+
+**统一要求**：安装后所有上述引用均不得再依赖开发目录相对路径，必须能解析到 `~/.claude/AgentDevFlow/` 或 `~/.claude/skills/` 下的稳定安装态路径。
+
+---
+
+## 2. 逐层依赖分析
+
+### 2.1 分析起点与范围
+
+**起点**：`skills/start-agent-team/SKILL.md`
+
+**分析覆盖的所有 Skill（10个）**：
+
+| # | Skill 目录 | 类别 | 准入判定 |
+|---|-----------|------|---------|
+| 1 | `start-agent-team/` | 入口 Skill | 必须 — 团队启动入口 |
+| 2 | `team-setup/` | 核心 Skill | 必须 — start-agent-team 直接引用 |
+| 3 | `product-manager/` | 核心 Skill | 必须 — start-agent-team Agent 创建映射 |
+| 4 | `architect/` | 核心 Skill | 必须 — start-agent-team Agent 创建映射 |
+| 5 | `qa-engineer/` | 核心 Skill | 必须 — start-agent-team Agent 创建映射 |
+| 6 | `engineer/` | 核心 Skill | 必须 — start-agent-team Agent 创建映射 |
+| 7 | `platform-sre/` | 核心 Skill | 必须 — start-agent-team Agent 创建映射 |
+| 8 | `pmo/` | 核心 Skill | 必须 — start-agent-team Agent 创建映射 |
+| 9 | `agent-bootstrap/` | 核心 Skill | 必须 — 自举启动入口 |
+| 10 | `pmo-review/` | 辅助 Skill | 必须 — pmo 增强能力 |
+
+**顶级共享文件**：
+- `skills/README.md` — 项目概述
+- `skills/skill-protocol.md` — 共享协议
+- `skills/event-bus.md` — 事件总线
+
+### 2.2 依赖分析矩阵
+
+以 start-agent-team 为起点，逐层展开的文件依赖：
+
+| Skill / 文件 | prompts/ | docs/ | docs/gov/ | workflows/ | shared/ | templates/ | scripts/ | 增强层 |
+|-------------|----------|-------|-----------|------------|---------|------------|----------|--------|
+| start-agent-team | 3项 | 0 | 0 | 5项 | 0 | 0 | 2项 | 引用 |
+| team-setup | 3项 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| product-manager | 7项 | 0 | 0 | 3项 | 0 | 2项 | 0 | 引用 |
+| architect | 7项 | 0 | 0 | 3项 | 0 | 2项 | 0 | 0 |
+| qa-engineer | 8项 | 0 | 0 | 4项 | 0 | 3项 | 0 | 引用 |
+| engineer | 8项 | 0 | 0 | 2项 | 0 | 1项 | 0 | 引用 |
+| platform-sre | 6项 | 0 | 1项 | 2项 | 0 | 2项 | 0 | 0 |
+| pmo | 8项 | 0 | 1项 | 2项 | 0 | 2项 | 0 | 引用 |
+| agent-bootstrap | 4项 | 1项 | 1项 | 0 | 0 | 0 | 0 | 0 |
+
+**补充说明**：
+- `engineer` 逐层依赖已在 Gate 2 前完成：其一级输入来自 8 个 prompts；二级输入来自 `skills/workflows/implementation.md`、`skills/workflows/qa-validation.md`；三级输入包含 `skills/templates/review-comment-template.md` 与增强层文档 `docs/platforms/enhancement-layer.md`。因此其最小必要安装集合为 prompts + workflows + templates + enhancement-layer 文档，**不再 defer**。
+- `platform-sre` 逐层依赖已在 Gate 2 前完成：其一级输入来自 6 个 prompts；二级输入来自 `docs/governance/platform-minimum-checks.md` 与 `skills/workflows/release-review.md`、`skills/workflows/anomaly-response.md`；三级输入来自 `skills/templates/release-record-template.md`、`skills/templates/platform-check-result-template.md`。因此其最小必要安装集合为 prompts + docs/governance + workflows + templates，**不再 defer**。
+- `agent-bootstrap` 逐层依赖已在 Gate 2 前完成：其一级输入来自 `prompts/002_develop_pipeline.md`、`prompts/001_team_topology.md`、`prompts/010_team_setup_and_bootstrap.md`；二级输入来自 `skills/start-agent-team.md`、`skills/skill-protocol.md`、`skills/event-bus.md`；三级输入来自 `docs/governance/core-principles.md` 与 `README.md`。因此其最小必要安装集合为 prompts + 顶级 shared skill 源文件 + docs/governance + README，**不再 defer**。
+- `docs/todo/` 与 `docs/memo/` 已显式分析：两者均被 start-agent-team / agent-bootstrap 的项目初始化语义间接涉及，但仅作为目标项目运行期状态目录存在，结论均为**不打包历史内容**；如需骨架能力，由安装后的初始化流程创建空目录或模板化起始文件。
+- 当前 9 个核心 skill（start-agent-team、team-setup、product-manager、architect、qa-engineer、engineer、platform-sre、pmo、agent-bootstrap）已全部完成逐层依赖分析，满足 PRD §7.7 “覆盖所有核心 skill”的 Gate 2 前置要求。
+- 当前仓库内 `skills/shared/` 为独立安装类别，即使本轮逐层依赖未发现显式文件级引用，也必须按 PRD 要求纳入安装产物、完备性检查与异常告警范围，避免后续 shared 资产落地时遗漏安装链路。
+
+### 2.3 关键 prompts 最小清单（解决 v1.0 Conditional 条件1）
+
+基于逐层依赖分析，以下为 **必须打包的 prompts 最小清单**：
+
+| # | 文件 | 准入理由 |
+|---|------|---------|
+| 1 | `prompts/001_team_topology.md` | 所有角色必读 |
+| 2 | `prompts/002_develop_pipeline.md` | 所有角色必读（核心流程） |
+| 3 | `prompts/004_delivery_gates.md` | PM/Architect/QA/Engineer 必读 |
+| 4 | `prompts/010_team_setup_and_bootstrap.md` | start-agent-team/team-setup 必读 |
+| 5 | `prompts/018_issue_routing_and_project_portfolio.md` | start-agent-team/team-setup 必读 |
+| 6 | `prompts/003_document_contracts.md` | PM/Architect/QA 必读 |
+| 7 | `prompts/007_issue_driven_orchestration.md` | PM/PMO 必读 |
+| 8 | `prompts/013_github_issue_and_review_comments.md` | PM/QA/PMO 必读 |
+| 9 | `prompts/017_human_review_and_signoff.md` | PM/Architect/QA/Engineer/PMO 必读 |
+| 10 | `prompts/019_dual_stage_pr_and_three_layer_safeguard.md` | PM/Engineer/Platform-SRE/PMO 必读 |
+
+**其他 prompts**（如 `002_product_engineering_roles.md`, `005_meeting_and_todo.md`, `008_change_record_and_revalidation.md` 等）在依赖矩阵中被引用但频次较低，归为**可选打包**（安装脚本应复制全部 prompts/ 目录，但完备性检查时优先验证最小清单）。
+
+### 2.4 关键 docs 最小清单
+
+| # | 文件/目录 | 准入理由 |
+|---|----------|---------|
+| 1 | `docs/governance/core-principles.md` | PMO 必读 |
+| 2 | `docs/governance/skill-protocol.md` | PMO 必读 |
+| 3 | `docs/governance/issue-naming-convention.md` | PMO 必读 |
+| 4 | `docs/governance/platform-minimum-checks.md` | Platform/SRE 必读 |
+| 5 | `docs/platforms/enhancement-layer.md` | PM/Architect/QA/PMO/Engineer 增强层引用 |
+
+### 2.4.1 docs/todo 与 docs/memo 依赖分析结论
+
+| 目录 | 结论 | 是否打包 | 理由 |
+|------|------|----------|------|
+| `docs/todo/` | 治理/运营运行态目录，当前仅在启动与项目状态维护中被引用 | **不打包** | 该目录承载目标项目自己的待办与阶段状态，属于运行期项目状态，不属于安装框架资产；安装后应由目标项目初始化生成，而不是携带 AgentDevFlow 仓库自身的历史任务数据 |
+| `docs/memo/` | 治理/运营运行态目录，当前用于 kickoff、status board、审计纪要和 issue 过程留痕 | **不打包** | 该目录保存项目实例自己的会议纪要、审计记录和恢复上下文，属于运行期项目产物；安装脚本应提供骨架能力，但不应分发本仓历史 memo 样例或具体 issue 留痕 |
+
+**结论说明**：
+- `docs/todo/` 与 `docs/memo/` 已纳入逐层依赖分析范围，结论为“**运行期生成目录，不应打包**”；
+- 其依赖语义属于“目录骨架/能力存在”而非“仓库内历史文件必须分发”；
+- 安装脚本若需要支持目标项目初始化，应在首次运行时创建对应空目录或模板化初始文件，但不得复制本仓现有 `TODO_REGISTRY.md`、kickoff memo、project status 等历史内容。
+
+### 2.5 关键 scripts 最小清单
+
+| # | 文件 | 准入理由 |
+|---|------|---------|
+| 1 | `scripts/github_issue_sync.py` | start-agent-team 直接调用 |
+| 2 | `scripts/task_router.py` | start-agent-team 直接调用 |
+| 3 | `scripts/task_update.py` | 被 task_router 依赖 |
+| 4 | `scripts/install.sh` | 安装脚本自身 |
+
+### 2.6 关键 workflows 最小清单
+
+| # | 文件 | 准入理由 |
+|---|------|---------|
+| 1 | `skills/workflows/tech-review.md` | Architect 必读 + start-agent-team 引用 |
+| 2 | `skills/workflows/qa-validation.md` | QA/Engineer 必读 + start-agent-team 引用 |
+| 3 | `skills/workflows/prd-review.md` | PM 必读 + start-agent-team 引用 |
+| 4 | `skills/workflows/release-review.md` | Platform-SRE 必读 + start-agent-team 引用 |
+| 5 | `skills/workflows/human-review.md` | PM/Architect/QA/Engineer 必读 |
+| 6 | `skills/workflows/implementation.md` | Engineer 必读 |
+| 7 | `skills/workflows/issue-lifecycle.md` | PMO 必读 |
+| 8 | `skills/workflows/weekly-review.md` | start-agent-team/PMO 引用 |
+
+### 2.7 关键 shared 最小清单
+
+| # | 文件/目录 | 准入理由 |
+|---|----------|---------|
+| 1 | `skills/shared/` | PRD 明确要求安装后校验 shared 类产物完整性；即使当前仓库共享资产为空，也必须保留稳定安装路径与检查位 |
+| 2 | `~/.claude/skills/shared/.keep` 或等效占位文件 | 当 shared 暂无业务文件时，确保安装态目录可创建、可检测、可告警 |
+| 3 | 后续新增 shared 资产 | 任一核心 skill / workflow 开始依赖 shared 内容后，必须同步进入最小清单、安装脚本复制逻辑与完备性检查 |
+
+**shared 目录规则**：
+- `skills/shared/` 定义为**必须存在的安装能力位，内容可为空**；
+- 当前若仓库 `skills/shared/` 为空，安装脚本仍需创建 `~/.claude/skills/shared/` 目录或等效占位文件；
+- 完备性检查需区分“目录缺失（fail）”与“目录存在但当前无共享资产（warn）”两种状态；
+- 一旦未来出现实际 shared 文件，shared 检查从“目录级”升级为“文件级最小清单”检查，无需修改路径模型。
+
+### 2.8 关键 templates 最小清单（解决 QA conditional 条件2）
+
+| # | 文件 | 准入理由 |
+|---|------|---------|
+| 1 | `skills/templates/tech-spec-template.md` | Architect 使用 |
+| 2 | `skills/templates/prd-template.md` | PM 使用 |
+| 3 | `skills/templates/qa-case-template.md` | QA 使用 |
+| 4 | `skills/templates/qa-report-template.md` | QA 使用 |
+| 5 | `skills/templates/review-comment-template.md` | 多角色共用 |
+| 6 | `skills/templates/audit-report-template.md` | PMO 使用 |
+| 7 | `skills/templates/release-record-template.md` | Platform/SRE 使用 |
+| 8 | `skills/templates/platform-check-result-template.md` | Platform/SRE 使用 |
+
+### 2.9 最小必要打包目录集
+
+基于依赖矩阵，以下为 **必须打包的目录集**（解决 PRD v1.0 "关键文件"未定义问题）：
+
+```
+必须打包（准入）：
+├── prompts/                    # 所有 prompts 文件
+├── docs/governance/            # 治理文档
+├── docs/platforms/             # 平台文档（含增强层）
+├── skills/*/SKILL.md           # 所有稳定版 skill 入口
+├── skills/README.md            # 项目概述
+├── skills/skill-protocol.md    # 共享协议
+├── skills/event-bus.md         # 事件总线
+├── skills/workflows/*.md       # 所有 workflow 文件
+├── skills/shared/              # shared 安装类别（当前可为空目录，但安装链路必须存在）
+├── skills/templates/*.md       # 所有 template 文件
+├── scripts/*.py                # 核心脚本
+├── scripts/install.sh          # 安装脚本自身
+└── README.md                   # 项目根 README（供参考）
+
+不应打包（准出）：
+├── .claude/                    # 运行时生成目录
+├── docs/prd/                   # 项目特定交付产物（PRD 模板除外）
+├── docs/tech/                  # 项目特定交付产物
+├── docs/qa/                    # 项目特定交付产物
+├── docs/memo/                  # 运行期纪要目录，历史内容不分发
+├── docs/todo/                  # 运行期状态目录，历史内容不分发
+├── docs/release/               # 项目特定交付产物
+├── docs/pmo/                   # 项目特定交付产物
+└── .github/                    # CI/CD 配置（非安装态必需）
+```
+
+**shared 准入说明**：`skills/shared/` 被视为独立安装类别，不以“当前是否已有业务文件”决定是否打包；目录本身属于路径契约的一部分，缺失即视为安装结果不完整。
+
+**todo/memo 准出说明**：`docs/todo/` 与 `docs/memo/` 已完成依赖分析，但其现存文件属于当前仓库运行历史，不属于安装给外部用户的框架资产；安装态若需要项目骨架，应通过初始化流程创建空目录/初始模板，而不是复制本仓历史数据。
+
+**"项目特定交付产物"界定**（解决 Minor note）：
+- **不打包**：已完成的 Issue 交付产物（`docs/prd/PRD-*.md`, `docs/tech/Tech-*.md`, `docs/qa/*_v*.md` 等）
+- **打包**：框架模板（`skills/templates/` 下的模板文件用于生成新文档）
+- **不打包**：历史 memo、release record、待办 registry
+
+---
+
+## 3. Skill 引用适配
+
+### 3.1 文档引用格式
+
+Skill 中的文档引用统一使用环境变量 `${ADF_DOC_ROOT}` 解析：
+
+```
+文档引用格式：${ADF_DOC_ROOT}/prompts/002_develop_pipeline.md
+其中 ADF_DOC_ROOT 由安装脚本设置，默认指向 ~/.claude/AgentDevFlow
+```
+
+### 3.2 安装前引用路径清理清单
+
+当前 skill 中存在以下开发目录相对路径引用，安装脚本必须重写：
+
+| 当前路径（开发态） | 安装态目标路径 | 处理方式 |
+|-------------------|---------------|---------|
+| `../../docs/platforms/enhancement-layer.md` | `${ADF_DOC_ROOT}/docs/platforms/enhancement-layer.md` | 安装时重写 |
+| `prompts/xxx.md`（无前缀） | `${ADF_DOC_ROOT}/prompts/xxx.md` | 安装时重写 |
+| `skills/workflows/xxx.md` | `~/.claude/skills/workflows/xxx.md`（相对 skill 路径） | 安装时重写 |
+| `skills/templates/xxx.md` | `~/.claude/skills/templates/xxx.md`（相对 skill 路径） | 安装时重写 |
+| `scripts/xxx.py` | `${ADF_DOC_ROOT}/scripts/xxx.py` | 安装时重写 |
+
+---
+
+## 4. ${ADF_DOC_ROOT} 注入时机与生命周期
+
+| 阶段 | 行为 |
+|---|---|
+| **首次安装** | 安装脚本检测 shell profile（`~/.bashrc`、`~/.zshrc`、`~/.config/fish/config.fish` 等），追加 `export ADF_DOC_ROOT="${HOME}/.claude/AgentDevFlow"` |
+| **重装 / 更新** | 安装脚本检查已有 `ADF_DOC_ROOT` 定义，若指向旧路径则替换为新路径；否则保留。写入 `.agentdevflow-version` 记录版本 |
+| **运行时** | Skill 启动时检测 `${ADF_DOC_ROOT}` 是否存在，缺失则 fallback 到 `${HOME}/.claude/AgentDevFlow` 并提示用户 |
+| **卸载** | 安装脚本提供 `--uninstall` 选项，可选移除环境变量声明（保留备份注释） |
+
+**持久化策略**：环境变量写入用户 shell profile，确保跨 session 生效；Claude Code Desktop/Web 继承系统环境变量。
+
+---
+
+## 5. 安装后完备性检查机制
+
+### 5.1 检查对象清单
+
+安装脚本在完成复制与环境变量注入后，必须立即执行一次**安装后内容完备性检查**。
+
+| 检查对象 | 预期安装路径 | 检查要求 | 成功判据 |
+|---|---|---|---|
+| prompts 最小清单 | `~/.claude/AgentDevFlow/prompts/` | 最小清单中 10 项全部存在且可读 | 10/10 通过 |
+| docs/governance | `~/.claude/AgentDevFlow/docs/governance/` | 目录存在，core-principles.md 等关键文件可读 | 关键文件全部存在 |
+| docs/platforms | `~/.claude/AgentDevFlow/docs/platforms/` | 目录存在，enhancement-layer.md 可读 | 文件存在 |
+| stable skills | `~/.claude/skills/` 下各稳定版 skill | 目标 skill 存在，且 `SKILL.md` 可读 | 所有 skill 目录与 `SKILL.md` 存在 |
+| workflows | `~/.claude/skills/workflows/` | 目录存在，关键 workflow 文件可读 | 8 项关键 workflow 全部存在 |
+| shared | `~/.claude/skills/shared/` | 目录必须存在；若当前无共享资产则允许为空目录或占位文件；若有共享资产则最小清单可读 | shared 路径存在，状态统一为 pass/fail/warn |
+| templates | `~/.claude/skills/templates/` | 目录存在，关键模板文件可读 | 8 项关键模板全部存在 |
+| scripts | `~/.claude/AgentDevFlow/scripts/` | 目录存在，核心脚本可读 | github_issue_sync.py, task_router.py 等存在 |
+| 环境变量 | `${ADF_DOC_ROOT}` | 已写入 shell profile 且可解析 | `echo $ADF_DOC_ROOT` 输出正确路径 |
+
+### 5.2 完备性检查输出格式（解决 QA conditional 条件1）
+
+检查结果以结构化 JSON 输出到标准输出（stdout），同时写入日志文件：
+
+```json
+{
+  "check_version": "2.0",
+  "timestamp": "2026-04-22T12:00:00Z",
+  "install_path": "~/.claude/AgentDevFlow",
+  "overall_status": "complete|incomplete",
+  "checks": [
+    {
+      "category": "prompts",
+      "path": "~/.claude/AgentDevFlow/prompts/",
+      "status": "pass|fail|warn",
+      "checked_items": 10,
+      "passed_items": 10,
+      "missing_items": [],
+      "details": "..."
+    },
+    {
+      "category": "shared",
+      "path": "~/.claude/skills/shared/",
+      "status": "pass|fail|warn",
+      "checked_items": 1,
+      "passed_items": 1,
+      "missing_items": [],
+      "details": "shared 目录存在；当前无共享业务文件时返回 warn，并提示该目录当前处于可接受空能力位状态"
+    }
+  ],
+  "missing_summary": {
+    "critical": [],
+    "warning": []
+  },
+  "recommendation": "安装完整，可继续使用。| 安装不完整，建议重新执行安装脚本。"
+}
+```
+
+**shared 状态解释**：
+- `pass`：shared 目录存在，且当前最小共享清单全部可读；
+- `warn`：shared 目录存在，但当前仓库无共享业务文件或仅有占位文件，属可接受空能力位状态；
+- `fail`：shared 目录不存在，或存在但约定的最小共享清单不可读。
+
+**日志文件位置**：`~/.claude/AgentDevFlow/.install-check.log`
+
+### 5.3 成功判据
+
+安装完成仅在以下条件同时满足时才可宣称**安装完整**：
+1. `~/.claude/AgentDevFlow/` 下 prompts/docs 存在且最小清单文件全部可读
+2. `~/.claude/skills/` 下稳定版 skill 路径存在，不包含安装态 `adf-` 前缀要求
+3. workflows/templates 均已落到稳定路径且关键引用可解析
+4. scripts/ 目录存在且核心脚本可读
+5. `${ADF_DOC_ROOT}` 已注入并可用于文档路径解析
+
+### 5.4 失败处理边界
+
+- 若检查发现缺失项，安装脚本必须输出缺失路径、失败项分类与重装建议
+- 缺失项应被标记为**安装不完整**，不得宣称安装成功闭环
+- 单个文档/模板/workflow 缺失时，不应阻断 Issue / Gate / PR 核心流程执行
+- 但一旦缺失影响关键引用解析，skill 必须显式提示用户修复安装
+- 若 stable skill 路径仍出现安装态 `adf-` 前缀要求，应判定为路径模型错误，而非用户环境问题
+- 完备性检查结果必须可供 QA 复核（通过 JSON 日志文件）
+
+### 5.5 关键入口最小验证集（解决 QA conditional 条件2）
+
+安装后以下三类入口必须可真实读取（不仅路径存在）：
+
+| 入口类别 | 最小验证集 | 验证方法 |
+|---------|-----------|---------|
+| 角色 SKILL | `skills/product-manager/SKILL.md` 中引用的 `prompts/002_develop_pipeline.md` | 通过模拟 Skill 加载读取目标文件 |
+| workflow | `skills/workflows/tech-review.md` | 直接读取文件内容 |
+| shared | `~/.claude/skills/shared/` 目录自身或约定占位文件 | 直接读取目录/占位文件状态，验证 shared 安装类别已真实落位 |
+| template | `skills/templates/prd-template.md` | 直接读取文件内容 |
+
+---
+
+## 6. Fallback 行为
+
+- 若 `${ADF_DOC_ROOT}` 缺失，skill fallback 到 `${HOME}/.claude/AgentDevFlow` 并提示用户
+- 若文档路径不存在，skill 应提示用户文档缺失并给出安装目录检查建议
+- 若 workflows/shared/templates 路径不存在，skill 应提示安装内容不完整并建议重新执行安装脚本
+- 不应因单个引用缺失而阻断核心流程执行
+- 核心流程（Issue/Gate/PR）不依赖单个引用文件存在性即可运行，但不得隐瞒安装缺失状态
+
+---
+
+## 7. 安装脚本更新范围
+
+### 7.1 新增/修改内容
+
+| 目标 | 动作 |
+|---|---|
+| **安装脚本** | 增加 prompts/、docs/、scripts/ 复制逻辑；增加 ADF_DOC_ROOT 注入逻辑；增加完备性检查 |
+| **skill 文件** | 重写所有开发目录相对路径引用为安装态可解析格式 |
+| **安装说明** | 说明安装后文档路径结构与稳定版 skill 路径结构 |
+| **CLAUDE.md** | 新增"安装目录打包规则"章节（§4.7 PRD 要求） |
+
+### 7.2 安装脚本伪代码
+
+```bash
+# install.sh 核心逻辑（v2.0）
+
+function install_dev() {
+    # 1. 复制 skills/ 到 ~/.claude/skills/（已有）
+    # 2. 复制 prompts/ 到 ~/.claude/AgentDevFlow/prompts/（新增）
+    # 3. 复制 docs/governance/ 到 ~/.claude/AgentDevFlow/docs/governance/（新增）
+    # 4. 复制 docs/platforms/ 到 ~/.claude/AgentDevFlow/docs/platforms/（新增）
+    # 5. 复制 scripts/ 到 ~/.claude/AgentDevFlow/scripts/（新增）
+    # 6. 注入 ADF_DOC_ROOT 到 shell profile（新增）
+    # 7. 执行完备性检查（新增）
+    # 8. 输出检查结果 JSON（新增）
+}
+```
+
+---
+
+## 8. Bootstrap-Sync 协同机制（解决 v1.0 Conditional 条件2）
+
+### 8.1 职责边界
+
+| 组件 | 职责 | 不涉及 |
+|------|------|--------|
+| **安装脚本** | 定义外部安装态路径、复制文件、注入环境变量、执行完备性检查 | 开发态自举 |
+| **bootstrap-sync** | 服务本仓开发态 `.claude/skills/adf-*` 自举产物 | 外部安装态路径 |
+| **skill 运行时** | 解析安装态路径、执行 fallback、暴露缺失告警 | 路径定义 |
+
+### 8.2 协同规则
+
+bootstrap-sync 在同步 skills 时，需遵守以下规则（与安装脚本不冲突）：
+
+1. bootstrap-sync **只**处理 `.claude/skills/adf-*/` 开发态产物，不触碰 `~/.claude/` 安装态目录
+2. bootstrap-sync 在生成 adf-* skill 时，同步检查 `${ADF_DOC_ROOT}` 路径下 prompts/ 和 docs/ 是否存在，缺失则输出警告（不自动复制，避免越权）
+3. 若开发目录的 prompts/ 或 docs/ 有变更，bootstrap-sync 在 CI 日志中提示"安装脚本可能需要同步更新"
+
+---
+
+## 9. CLAUDE.md 规则沉淀（§4.7 PRD 要求）
+
+### 9.1 目标文件
+
+**项目级 CLAUDE.md**：`/home/work/code/AgentDevFlow/CLAUDE.md`（非 Human 全局级）
+
+### 9.2 新增章节内容
+
+在现有 CLAUDE.md 末尾新增"安装目录打包规则"章节，包含：
+
+1. **打包目录清单**：明确列出 §2.8 中的必须打包目录集
+2. **目录依赖变更规则**：新增目录必须经过 Architect 评估 + Tech Review 签字
+3. **开发态 vs 安装态区分**：
+   - 开发态：`.claude/skills/adf-*`（bootstrap-sync 产物）
+   - 安装态：`~/.claude/skills/`（稳定版，无 adf- 前缀）
+4. **引用路径规范**：skill 中引用文件必须使用 `${ADF_DOC_ROOT}` 或稳定版 skill 路径
+5. **安装脚本更新同步规则**：任何新增目录依赖必须同步更新安装脚本的复制逻辑 + 完备性检查 + 安装说明
+
+---
+
+## 10. 接口
+
+- **输入**：PRD #019 v2.0、当前安装脚本、当前 skill 文档引用现状、依赖分析矩阵
+- **输出**：
+  - 路径映射与安装态解析方案
+  - 依赖分析矩阵文档（`docs/tech/019_dependency_matrix.md`）
+  - 完备性检查机制
+  - 更新后的安装脚本
+  - 更新后的 skill 引用路径
+  - 更新后的 CLAUDE.md
+  - QA Case
+
+---
+
+## 11. 可测试性
+
+QA 可验证：
+
+1. 安装后 prompts/ 和 docs/ 是否存在于安装目录
+2. 安装后 stable skills/workflows/templates 是否存在于 `~/.claude/skills/` 稳定路径
+3. skill 中的文档引用是否在安装后仍可解析
+4. skill 中对 workflows/shared/templates 的关键引用是否在安装后可解析
+5. 缺失项出现时是否输出明确告警，并标记为安装不完整
+6. 单个引用缺失时是否不阻断核心流程，但不隐藏失败状态
+7. 安装说明是否说明路径结构与完备性检查边界
+8. **新增**：依赖分析矩阵是否覆盖所有核心 skill
+9. **新增**：打包目录准入/准出规则是否与依赖矩阵一致
+10. **新增**：CLAUDE.md 中是否新增打包规则章节且与 PRD 一致
+11. **新增**：完备性检查 JSON 输出是否结构化且可复核
+12. **新增**：三类关键入口是否可真实读取目标内容
+
+---
+
+## 12. 风险
+
+| 风险 | 级别 | 缓解 |
+|---|---|---|
+| 文档复制与源文件不同步 | 高 | 明确文档更新时同步复制机制；bootstrap-sync CI 提示 |
+| 环境变量未设置导致路径失效 | 中 | 安装脚本负责设置，skill 检测缺失时给出提示 |
+| stable skills/workflows/templates 未完整安装 | 高 | 安装后立即执行完备性检查并输出缺失清单 |
+| 开发态 adf- 前缀与安装态稳定路径混淆 | 中 | 在 Tech 中显式区分本仓自举与外部安装态 |
+| 不同操作系统路径差异 | 低 | 使用跨平台路径库 |
+| 逐层依赖分析遗漏 skill 或目录 | 高 | 以 start-agent-team 为入口逐层展开，产出矩阵逐项核对 |
+| CLAUDE.md 规则与实际安装脚本不一致 | 高 | 规则更新与安装脚本修改同步进行，QA 验证两者一致性 |
+| 增强层文档路径引用未处理 | 中 | 已将 `docs/platforms/enhancement-layer.md` 纳入必须打包清单 |
+
+---
+
+## 13. 发布推进
+
+Gate 2 → QA Case → 安装脚本/文档/CLAUDE.md 更新 → 文档 PR → HR#1 → Release
+
+---
+
+## 14. 回滚
+
+- 若路径映射导致安装复杂度显著上升，回退到当前最小必要路径映射并重新评估方案
+- 若完备性检查范围过大导致安装不可维护，先保留 prompts/docs + 关键 workflows/templates 检查，其余纳入下一轮补齐
+- 若 CLAUDE.md 规则与现有内容冲突，优先保留现有架构设计，将新规则作为补充章节
+
+---
+
+## 15. 评审记录
+
+| 日期 | 评审人 | 备注 | 决策 |
+|---|---|---|---|
+| 2026-04-22 | Architect | 起草 Tech Draft v1.0 | Draft |
+| 2026-04-22 | Architect | v1.1 PM Conditional 修订 | Draft |
+| 2026-04-22 | Architect | v1.2 吸收 #30 有效技术点 | Draft |
+| 2026-04-22 | PM | 流程违规纠正：Tech Spec 基于未 Approved PRD 起草，签字撤销 | 降级/撤销 |
+| 2026-04-22 | Architect | **v2.0 重新起草**：基于 PRD v2.0 重大变更，新增逐层依赖分析（§2）、打包目录规则（§2.8）、CLAUDE.md 沉淀（§9）、完备性检查 JSON 输出格式（§5.2）、关键入口最小验证集（§5.5）、bootstrap-sync 协同细化（§8） | Draft |
+| 2026-04-22 | PMO/Team Lead | **违规标记**：Architect 在 Gate 1 正式留痕未补齐前完成 Tech Spec v2.0 起草，违反 PMO 纠正动作时序要求。Tech Spec 内容保留但需 Gate 1 留痕补齐后重新评估 | 违规/待复核 |
+| 2026-04-22 | PM | **Gate 1 正式通过**：PRD v2.0 三方签字完成（PM + Architect + QA），违规标记解除，Tech Spec 进入正常 Gate 2 评审流程 | Approved |
+| 2026-04-22 | QA + Engineer + PM | Gate 2 完成：shared 口径、JSON schema、依赖分析覆盖等条件项已收口，Tech Spec 通过三方评审 | Approved |
+
+---
+
+## 16. 版本历史
+
+| 版本 | 日期 | 变更说明 | 变更人 |
+|------|------|---------|-------|
+| v1.0 | 2026-04-22 | 首次起草 | Architect |
+| v1.1 | 2026-04-22 | PM Conditional 修订：统一采用方案A | Architect |
+| v1.2 | 2026-04-22 | 吸收 #30 有效技术点 | Architect |
+| v2.0 | 2026-04-22 | **重大重写**：基于 PRD v2.0 新增 §4.5-4.7 内容；新增逐层依赖分析矩阵、打包目录准入/准出规则、CLAUDE.md 规则沉淀章节；解决 v1.0 Conditional 条件（关键文件定义、bootstrap-sync 细化）；解决 QA conditional 条件（输出格式、最小验证集） | Architect |

--- a/docs/todo/TODO_REGISTRY.md
+++ b/docs/todo/TODO_REGISTRY.md
@@ -2,9 +2,9 @@
 
 ## 项目信息
 - `project_id`: alpha-86-AgentDevFlow
-- 当前主任务: #20
-- 关联业务 issue: #3（暂停中，待 #20 完成后恢复）
-- 当前阶段: #20 治理修复主体已完成，待同步正式留痕并验收；#3 Gate 2 Tech Review 暂停
+- 当前主任务: #19（最高优先级）
+- 关联治理 issue: #20（已关闭 / 已验收归档，作为返工背景保留）
+- 当前阶段: #19 Gate 1 PRD v2.0 Approved（三方签字），推进 Gate 2: Tech Review
 - 启动方式: 2026-04-21 团队重启（全新 session）
 - 启动会纪要: `docs/memo/kickoff_2026-04-21.md`
 
@@ -24,49 +24,67 @@
 
 | 任务 | Issue | 负责人 | 状态 | 说明 |
 |------|-------|--------|------|------|
-| GOV-011 治理修复 | #20 | PM + PMO | 🔄 in_progress | 最高优先级，Issue #3 暂停 |
+| #3 PRD 返工并重进 Gate 1 | #3 | PM | 🔄 in_progress | 当前主任务，PRD v4.2 已产出，待重新发起 Gate 1 三方评审 |
+| GOV-011 治理修复收口 | #20 | PM + PMO | ✅ completed | 已完成治理修复与正式留痕，作为 #3 返工背景保留 |
 
-### #20 Action Items
+### #3 Action Items
 
 | Action Item | Owner | Due | Evidence | Status |
 |------------|-------|-----|----------|--------|
-| 同步主线留痕：registry / kickoff / status board 口径一致 | PM | 2026-04-21 | `docs/todo/TODO_REGISTRY.md`, `docs/memo/kickoff_2026-04-21.md`, `docs/memo/project_status_2026-04-21.md` | ✅ 已完成 |
-| 准备 PM 结构化评论草稿，待正式回写 Issue #20 | PM | 2026-04-21 | `docs/memo/issue_20_pm_structured_comment_draft_2026-04-21.md` | ✅ 已完成 |
-| Team Lead / PMO 对治理修复结果执行验收确认 | Team Lead + PMO | 2026-04-21 | Issue #20 验收评论 / 后续验收留痕 | ⏳ 待完成 |
+| 产出 PRD v4.2，作为回退后 Gate 1 正式输入 | PM | 2026-04-21 | `docs/prd/003_adf_enhancement_layer_2026-04-17.md` | ✅ 已完成 |
+| 在 Issue #3 回写 PM 结构化 comment，声明回退到 Gate 1 | PM | 2026-04-21 | Issue #3 comment | ⏳ 待完成 |
+| 组织 Gate 1 三方评审（PM + Architect + QA） | Team Lead | 2026-04-21 | Gate 1 评审结论 / Issue #3 comment | ⏳ 待完成 |
+
+### #20 Action Items
+
+> Issue #20 已关闭 / 已验收归档。本节仅保留归档说明，不再保留待验收 action item。
 
 ## 待处理 Issue (Open)
 
 | Issue | 标题 | 类型 | 优先级 | 路由 | 状态 |
 |-------|------|------|--------|------|------|
-| #20 | GOV-011 HR#1 流程违规 | governance | medium | PM + PMO | 治理修复主体已完成，待同步正式留痕并验收 |
-| #3 | gstack/superpower 增强层接入 | feature | high | PM | ⏸️ 暂停（关联业务 issue，等 #20 完成后恢复） |
+| #3 | gstack/superpower 增强层接入 | feature | high | PM | 已恢复，当前阶段 = Gate 1: PRD Review（返工输入 v4.2） |
 | #5 | ADF 技能系统完善 | feature | medium | PM | pending |
-| #8 | GOV-004 HR#1 被跳过 | process | medium | PMO | pending |
+| #8 | GOV-004 HR#1 被跳过 | process | medium | PM | ⏳ 待进入 Gate 1: PRD Review |
 | #16 | GOV-009 职责归属矩阵缺失 | governance | medium | PM | pending |
 | #17 | GOV-010 Skill 结构冲突 | governance | medium | PM | pending |
 | #18 | Agent 获取 Issue Comment 不规范 | bug | medium | PM | pending |
-| #19 | 安装脚本 bug 问题 | bug | medium | PM | pending |
+| #19 | 安装脚本 bug 问题 | bug | **high** | PM | ✅ Gate 1 PRD v2.0 Approved，推进 Gate 2 Tech Review |
 | #21 | prompts 原则：禁止单一 pattern 式描述 | process | medium | PM | pending |
 
-## Gate 状态 (Issue #3 — 暂停)
+## Gate 状态 (Issue #19 — 当前最高优先级主线)
 
 | Gate | 状态 | 说明 |
 |------|------|------|
 | Gate 0: Team Startup | ✅ 已完成 | 2026-04-21 重启 |
-| Gate 1: PRD Review | ✅ 历史通过 | v4.1 (2026-04-17) |
-| Gate 2: Tech Review | ⏸️ 暂停 | 待 Issue #20 完成后恢复 |
-| QA Case Design | ⏸️ 暂停 | — |
-| 文档 PR / HR#1 | ⏸️ 暂停 | — |
-| Gate 3: Implementation | ⏸️ 暂停 | — |
-| Gate 4: QA Validation | ⏸️ 暂停 | — |
-| 代码 PR / HR#2 | ⏸️ 暂停 | — |
-| Gate 5: Release | ⏸️ 暂停 | — |
+| Gate 1: PRD Review | ✅ Approved | PRD v2.0 三方签字：PM[✅] Architect[✅] QA[✅ Conditional] |
+| Gate 2: Tech Review | ✅ Approved | Tech Spec v2.0 已完成 Gate 2 收口，可作为当前有效输入 |
+| QA Case Design | ✅ Approved | QA Case v2.0 已完成评审收口，可作为当前有效输入 |
+| 文档 PR / HR#1 | 🔄 推进中 | PRD / Tech / QA 三份正式文档已齐备，进入文档 PR / HR#1 前置收敛 |
+| Gate 3: Implementation | ⛔ 未开始 | — |
+| Gate 4: QA Validation | ⛔ 未开始 | — |
+| 代码 PR / HR#2 | ⛔ 未开始 | — |
+| Gate 5: Release | ⛔ 未开始 | — |
+
+## Gate 状态 (Issue #3)
+
+| Gate | 状态 | 说明 |
+|------|------|------|
+| Gate 0: Team Startup | ✅ 已完成 | 2026-04-21 重启 |
+| Gate 1: PRD Review | 🔄 in_progress | 已回退并重置为 PRD v4.2 输入，待重新三方评审 |
+| Gate 2: Tech Review | ⛔ 未开始 | 旧 Tech Review 仅作历史留档，不作为当前有效前提 |
+| QA Case Design | ⛔ 未开始 | 旧 QA Case 仅作历史留档，不作为当前有效前提 |
+| 文档 PR / HR#1 | ⛔ 未开始 | 待 Gate 1 / Gate 2 / QA Case 重新完成 |
+| Gate 3: Implementation | ⛔ 未开始 | — |
+| Gate 4: QA Validation | ⛔ 未开始 | — |
+| 代码 PR / HR#2 | ⛔ 未开始 | — |
+| Gate 5: Release | ⛔ 未开始 | — |
 
 ## 启动会
 
 - 时间: 2026-04-21
 - 负责人: Team Lead
-- 结论: 团队重启，6 个 Agent 初始化完成，当前聚焦 Issue #20 治理修复
+- 结论: 团队重启后，当前主线已切换为 Issue #3 的 PRD 返工与 Gate 1 重审
 - 纪要: `docs/memo/kickoff_2026-04-21.md`
 
 ## 历史审计记录（2026-04-17，Issue #3）
@@ -77,7 +95,7 @@
 |---|--------|---------|---------|
 | 1 | PRD 命名不符合标准（`PRD-3_v3.md`） | PM（初次）→ Human（rename 已纠正） | ✅ 已纠正 |
 | 2 | 直接 push 到 main 而非通过 PR | Human 操作，PMO 审计范围外 | ⚠️ 待规范 |
-| 3 | 在 Human 确认前发起 Gate 1 评审（声称 v3 "Human 确认" 但缺乏独立证据） | PM | ⚠️ 待 PM 区分"Human 反馈"与"Human 确认" |
+| 3 | 在 Human 确认前发起 Gate 1 评审（声称 v3 "Human 确认" 但缺乏独立证据） | PM | ⚠️ 本轮 Gate 1 前仍需补齐证据 |
 | 4 | PR #1 不存在（历史示例文件误解） | PM 误解 | ✅ 已澄清 |
 | 5 | PM 发布 Issue 关闭评论（Issue 关闭是 Human 专属） | PM Agent（历史） | ✅ Human 已重新打开纠正 |
 


### PR DESCRIPTION
## Summary
- consolidate the approved #19 PRD, tech spec, QA case, and registry state into one HR#1 document package
- keep #19 as the only active document-review mainline and #30 as background only
- prepare the exact inputs Human Review #1 should evaluate for document-stage completeness

## Human Review #1 input
- `docs/prd/019_installation_script_doc_path_2026-04-22.md`
- `docs/tech/019_installation_script_doc_path_tech_2026-04-22.md`
- `docs/qa/019_installation_script_doc_path_qa_2026-04-22.md`
- `docs/todo/TODO_REGISTRY.md`
- review scope: document-stage completeness for Issue #19 only, not implementation details

## Test plan
- [x] Verify PRD status is Approved
- [x] Verify Tech Spec status is Approved
- [x] Verify QA Case status is Approved
- [x] Verify TODO_REGISTRY gate states align with PRD / Tech / QA
- [ ] Human Review #1 validates document-stage completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)